### PR TITLE
feat: Sprint 2 - コンテキスト管理

### DIFF
--- a/src/app/(authenticated)/contexts/[id]/page.tsx
+++ b/src/app/(authenticated)/contexts/[id]/page.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { useEffect, useState, useMemo } from "react";
+import { useRouter, useParams } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import { GlossaryEditor } from "@/components/contexts/GlossaryEditor";
+import type { Context, ContextType, GlossaryEntry } from "@/types/database";
+
+const typeLabels: Record<string, string> = {
+  theme_park: "テーマパーク",
+  museum: "博物館",
+  theater: "演劇",
+  other: "その他",
+};
+
+export default function ContextDetailPage() {
+  const params = useParams();
+  const router = useRouter();
+  const supabase = useMemo(() => createClient(), []);
+  const id = params.id as string;
+
+  const [context, setContext] = useState<Context | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [title, setTitle] = useState("");
+  const [sourceUrl, setSourceUrl] = useState("");
+  const [glossary, setGlossary] = useState<GlossaryEntry[]>([]);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    async function fetchContext() {
+      const { data } = await supabase
+        .from("contexts")
+        .select("*")
+        .eq("id", id)
+        .single<Context>();
+      if (data) {
+        setContext(data);
+        setTitle(data.title);
+        setSourceUrl(data.source_url || "");
+        setGlossary(data.glossary as GlossaryEntry[]);
+      }
+      setLoading(false);
+    }
+    fetchContext();
+  }, [id, supabase, refreshKey]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    await supabase
+      .from("contexts")
+      .update({
+        title,
+        source_url: sourceUrl || null,
+        glossary,
+        keywords: glossary.map((g) => g.en),
+      })
+      .eq("id", id);
+    setSaving(false);
+    setRefreshKey((k) => k + 1);
+  };
+
+  const handleDelete = async () => {
+    if (!confirm("このコンテキストを削除しますか？")) return;
+    await supabase.from("contexts").delete().eq("id", id);
+    router.push("/contexts");
+  };
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (!context) {
+    return (
+      <div className="px-4 py-6 text-center">
+        <p className="text-sm text-text-muted">コンテキストが見つかりません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 py-6">
+      {/* Header */}
+      <div className="mb-6 flex items-center gap-3">
+        <Link href="/contexts" className="text-text-secondary">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="m15 18-6-6 6-6" />
+          </svg>
+        </Link>
+        <div>
+          <h2 className="font-display text-lg font-bold text-text-primary">
+            コンテキスト詳細
+          </h2>
+          <p className="text-xs text-text-muted">
+            {typeLabels[context.type as ContextType]}
+          </p>
+        </div>
+      </div>
+
+      {/* Edit form */}
+      <div className="space-y-4">
+        <div>
+          <label className="mb-1 block text-xs font-medium text-text-secondary">
+            タイトル
+          </label>
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="w-full rounded-[10px] border border-border bg-bg-input px-4 py-3 text-sm text-text-primary focus:border-primary focus:outline-none"
+          />
+        </div>
+
+        <div>
+          <label className="mb-1 block text-xs font-medium text-text-secondary">
+            参考URL
+          </label>
+          <input
+            type="url"
+            value={sourceUrl}
+            onChange={(e) => setSourceUrl(e.target.value)}
+            placeholder="https://..."
+            className="w-full rounded-[10px] border border-border bg-bg-input px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:border-primary focus:outline-none"
+          />
+        </div>
+
+        <GlossaryEditor glossary={glossary} onChange={setGlossary} />
+
+        {/* Action buttons */}
+        <div className="space-y-3 pt-4">
+          <button
+            onClick={handleSave}
+            disabled={saving || !title.trim()}
+            className="w-full rounded-xl bg-primary py-[13px] text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+          >
+            {saving ? "保存中..." : "保存"}
+          </button>
+
+          <Link
+            href={`/live?contextId=${context.id}`}
+            className="flex w-full items-center justify-center rounded-xl border border-primary py-[13px] text-sm font-semibold text-primary transition-colors hover:bg-primary/5"
+          >
+            このコンテキストで翻訳開始
+          </Link>
+
+          <button
+            onClick={handleDelete}
+            className="w-full rounded-xl py-[13px] text-sm font-semibold text-destructive transition-colors hover:bg-destructive/5"
+          >
+            コンテキストを削除
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(authenticated)/contexts/new/page.tsx
+++ b/src/app/(authenticated)/contexts/new/page.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import { TemplatePicker } from "@/components/contexts/TemplatePicker";
+import { ContextForm } from "@/components/contexts/ContextForm";
+import type { ContextType, GlossaryEntry } from "@/types/database";
+
+type Tab = "template" | "manual";
+
+export default function NewContextPage() {
+  const [tab, setTab] = useState<Tab>("template");
+  const [loading, setLoading] = useState(false);
+  const router = useRouter();
+  const supabase = createClient();
+
+  const handleTemplateSelect = async (templateId: string) => {
+    setLoading(true);
+    const { data: template } = await supabase
+      .from("context_templates")
+      .select("*")
+      .eq("id", templateId)
+      .single();
+
+    if (!template) {
+      setLoading(false);
+      return;
+    }
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+
+    const { data: context } = await supabase
+      .from("contexts")
+      .insert({
+        user_id: user.id,
+        type: template.type,
+        title: template.title,
+        researched_data: template.researched_data,
+        glossary: template.glossary,
+        keywords: template.keywords,
+        status: "ready" as const,
+      })
+      .select()
+      .single();
+
+    if (context) {
+      router.push(`/contexts/${context.id}`);
+    }
+    setLoading(false);
+  };
+
+  const handleManualCreate = async (data: {
+    type: ContextType;
+    title: string;
+    source_url: string;
+    glossary: GlossaryEntry[];
+  }) => {
+    setLoading(true);
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      setLoading(false);
+      return;
+    }
+
+    const { data: context } = await supabase
+      .from("contexts")
+      .insert({
+        user_id: user.id,
+        type: data.type,
+        title: data.title,
+        source_url: data.source_url || null,
+        glossary: data.glossary,
+        keywords: data.glossary.map((g) => g.en),
+        status: "ready" as const,
+      })
+      .select()
+      .single();
+
+    if (context) {
+      router.push(`/contexts/${context.id}`);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="px-4 py-6">
+      {/* Header */}
+      <div className="mb-4 flex items-center gap-3">
+        <Link href="/contexts" className="text-text-secondary">
+          <svg
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="m15 18-6-6 6-6" />
+          </svg>
+        </Link>
+        <h2 className="font-display text-lg font-bold text-text-primary">
+          コンテキスト追加
+        </h2>
+      </div>
+
+      {/* Tabs */}
+      <div className="mb-6 flex rounded-xl bg-bg-card p-1">
+        <button
+          onClick={() => setTab("template")}
+          className={`flex-1 rounded-lg py-2.5 text-sm font-medium transition-colors ${
+            tab === "template"
+              ? "bg-primary text-primary-foreground"
+              : "text-text-secondary"
+          }`}
+        >
+          テンプレート
+        </button>
+        <button
+          onClick={() => setTab("manual")}
+          className={`flex-1 rounded-lg py-2.5 text-sm font-medium transition-colors ${
+            tab === "manual"
+              ? "bg-primary text-primary-foreground"
+              : "text-text-secondary"
+          }`}
+        >
+          手動作成
+        </button>
+      </div>
+
+      {/* Content */}
+      {tab === "template" ? (
+        <TemplatePicker onSelect={handleTemplateSelect} loading={loading} />
+      ) : (
+        <ContextForm onSubmit={handleManualCreate} loading={loading} />
+      )}
+    </div>
+  );
+}

--- a/src/app/(authenticated)/contexts/page.tsx
+++ b/src/app/(authenticated)/contexts/page.tsx
@@ -1,16 +1,102 @@
+"use client";
+
+import { useEffect, useState, useMemo, useCallback } from "react";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/client";
+import { ContextCard } from "@/components/contexts/ContextCard";
+import type { Context } from "@/types/database";
+
+const PAGE_SIZE = 20;
+
 export default function ContextsPage() {
+  const [contexts, setContexts] = useState<Context[]>([]);
+  const [total, setTotal] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const supabase = useMemo(() => createClient(), []);
+
+  const fetchContexts = useCallback(
+    async (offset = 0) => {
+      setLoading(true);
+      const { data, count } = await supabase
+        .from("contexts")
+        .select("*", { count: "exact" })
+        .order("updated_at", { ascending: false })
+        .range(offset, offset + PAGE_SIZE - 1);
+
+      if (data) {
+        if (offset === 0) {
+          setContexts(data);
+        } else {
+          setContexts((prev) => [...prev, ...data]);
+        }
+      }
+      if (count !== null) setTotal(count);
+      setLoading(false);
+    },
+    [supabase],
+  );
+
+  useEffect(() => {
+    fetchContexts();
+  }, [fetchContexts]);
+
   return (
     <div className="px-4 py-6">
-      <h2 className="font-display text-lg font-bold text-text-primary">
-        コンテキスト
-      </h2>
-      <div className="mt-8 flex flex-col items-center py-12 text-center">
-        <p className="text-sm text-text-muted">
-          コンテキストがありません。
-          <br />
-          テンプレートから追加するか、手動で作成しましょう。
-        </p>
+      <div className="flex items-center justify-between">
+        <h2 className="font-display text-lg font-bold text-text-primary">
+          コンテキスト
+        </h2>
       </div>
+
+      {loading && contexts.length === 0 ? (
+        <div className="flex justify-center py-12">
+          <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        </div>
+      ) : contexts.length === 0 ? (
+        <div className="mt-8 flex flex-col items-center py-12 text-center">
+          <p className="text-sm text-text-muted">
+            コンテキストがありません。
+            <br />
+            テンプレートから追加するか、手動で作成しましょう。
+          </p>
+        </div>
+      ) : (
+        <div className="mt-4 space-y-3">
+          {contexts.map((context) => (
+            <ContextCard key={context.id} context={context} />
+          ))}
+
+          {contexts.length < total && (
+            <button
+              onClick={() => fetchContexts(contexts.length)}
+              disabled={loading}
+              className="w-full rounded-lg border border-border py-3 text-sm text-text-secondary hover:bg-bg-card disabled:opacity-50"
+            >
+              {loading ? "読み込み中..." : "もっと見る"}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* FAB */}
+      <Link
+        href="/contexts/new"
+        className="fixed bottom-20 right-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-colors hover:bg-primary/90"
+      >
+        <svg
+          width="24"
+          height="24"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="M5 12h14" />
+          <path d="M12 5v14" />
+        </svg>
+      </Link>
     </div>
   );
 }

--- a/src/app/api/contexts/[id]/route.ts
+++ b/src/app/api/contexts/[id]/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from "next/server";
+import { getAuthUser } from "@/lib/auth";
+import { z } from "zod";
+
+const updateContextSchema = z.object({
+  type: z.enum(["theme_park", "museum", "theater", "other"]).optional(),
+  title: z.string().min(1).optional(),
+  source_url: z.string().url().optional().or(z.literal("")).or(z.null()),
+  glossary: z
+    .array(z.object({ en: z.string(), ja: z.string(), category: z.string().optional() }))
+    .max(20)
+    .optional(),
+  keywords: z.array(z.string()).optional(),
+});
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const { supabase } = await getAuthUser();
+
+  const { data, error } = await supabase
+    .from("contexts")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 404 });
+  }
+
+  return NextResponse.json(data);
+}
+
+export async function PUT(
+  request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const { supabase } = await getAuthUser();
+
+  const body = updateContextSchema.parse(await request.json());
+
+  const updateData: Record<string, unknown> = {};
+  if (body.type !== undefined) updateData.type = body.type;
+  if (body.title !== undefined) updateData.title = body.title;
+  if (body.source_url !== undefined)
+    updateData.source_url = body.source_url || null;
+  if (body.glossary !== undefined) {
+    updateData.glossary = body.glossary;
+    // Auto-extract keywords from glossary EN side
+    if (!body.keywords) {
+      updateData.keywords = body.glossary.map((g) => g.en);
+    }
+  }
+  if (body.keywords !== undefined) updateData.keywords = body.keywords;
+
+  const { data, error } = await supabase
+    .from("contexts")
+    .update(updateData)
+    .eq("id", id)
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data);
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const { supabase } = await getAuthUser();
+
+  const { error } = await supabase.from("contexts").delete().eq("id", id);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return new Response(null, { status: 204 });
+}

--- a/src/app/api/contexts/route.ts
+++ b/src/app/api/contexts/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { getAuthUser } from "@/lib/auth";
+import { z } from "zod";
+
+const createContextSchema = z.object({
+  type: z.enum(["theme_park", "museum", "theater", "other"]).default("other"),
+  title: z.string().min(1),
+  source_url: z.string().url().optional().or(z.literal("")),
+  glossary: z
+    .array(z.object({ en: z.string(), ja: z.string(), category: z.string().optional() }))
+    .max(20)
+    .default([]),
+  keywords: z.array(z.string()).default([]),
+});
+
+export async function GET(request: Request) {
+  const { supabase } = await getAuthUser();
+  const { searchParams } = new URL(request.url);
+
+  const limit = Math.min(Number(searchParams.get("limit") || "20"), 50);
+  const offset = Number(searchParams.get("offset") || "0");
+
+  const { data, error, count } = await supabase
+    .from("contexts")
+    .select("*", { count: "exact" })
+    .order("updated_at", { ascending: false })
+    .range(offset, offset + limit - 1);
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json({ data, total: count });
+}
+
+export async function POST(request: Request) {
+  const { supabase, user } = await getAuthUser();
+
+  const body = createContextSchema.parse(await request.json());
+
+  const { data, error } = await supabase
+    .from("contexts")
+    .insert({
+      user_id: user.id,
+      type: body.type,
+      title: body.title,
+      source_url: body.source_url || null,
+      glossary: body.glossary,
+      keywords:
+        body.keywords.length > 0
+          ? body.keywords
+          : body.glossary.map((g) => g.en),
+      status: "ready" as const,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data, { status: 201 });
+}

--- a/src/app/api/templates/[id]/route.ts
+++ b/src/app/api/templates/[id]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { getAuthUser } from "@/lib/auth";
+
+export async function GET(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const { supabase } = await getAuthUser();
+
+  const { data, error } = await supabase
+    .from("context_templates")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 404 });
+  }
+
+  return NextResponse.json(data);
+}

--- a/src/app/api/templates/[id]/use/route.ts
+++ b/src/app/api/templates/[id]/use/route.ts
@@ -1,0 +1,48 @@
+import { NextResponse } from "next/server";
+import { getAuthUser } from "@/lib/auth";
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const { supabase, user } = await getAuthUser();
+
+  // Fetch the template
+  const { data: template, error: templateError } = await supabase
+    .from("context_templates")
+    .select("*")
+    .eq("id", id)
+    .single();
+
+  if (templateError || !template) {
+    return NextResponse.json(
+      { error: "Template not found" },
+      { status: 404 },
+    );
+  }
+
+  // Create a context from the template
+  const { data: context, error: contextError } = await supabase
+    .from("contexts")
+    .insert({
+      user_id: user.id,
+      type: template.type,
+      title: template.title,
+      researched_data: template.researched_data,
+      glossary: template.glossary,
+      keywords: template.keywords,
+      status: "ready" as const,
+    })
+    .select()
+    .single();
+
+  if (contextError) {
+    return NextResponse.json(
+      { error: contextError.message },
+      { status: 500 },
+    );
+  }
+
+  return NextResponse.json(context, { status: 201 });
+}

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from "next/server";
+import { getAuthUser } from "@/lib/auth";
+
+export async function GET() {
+  const { supabase } = await getAuthUser();
+
+  const { data, error } = await supabase
+    .from("context_templates")
+    .select("id, type, park, title, description, sort_order")
+    .order("sort_order", { ascending: true });
+
+  if (error) {
+    return NextResponse.json({ error: error.message }, { status: 500 });
+  }
+
+  return NextResponse.json(data);
+}

--- a/src/components/contexts/ContextCard.tsx
+++ b/src/components/contexts/ContextCard.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+import type { Context } from "@/types/database";
+
+const typeLabels: Record<string, string> = {
+  theme_park: "テーマパーク",
+  museum: "博物館",
+  theater: "演劇",
+  other: "その他",
+};
+
+export function ContextCard({ context }: { context: Context }) {
+  return (
+    <Link
+      href={`/contexts/${context.id}`}
+      className="block rounded-xl border border-border bg-bg-card p-4 transition-colors hover:bg-bg-input"
+    >
+      <div className="flex items-start justify-between">
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate text-sm font-semibold text-text-primary">
+            {context.title}
+          </h3>
+          <p className="mt-1 text-xs text-text-secondary">
+            {typeLabels[context.type] || context.type}
+          </p>
+        </div>
+        <span className="ml-2 shrink-0 rounded-full bg-success/10 px-2 py-0.5 text-xs font-medium text-success">
+          {context.status}
+        </span>
+      </div>
+      {Array.isArray(context.glossary) &&
+        (context.glossary as Array<{ en: string }>).length > 0 && (
+          <p className="mt-2 text-xs text-text-muted">
+            用語: {(context.glossary as Array<{ en: string }>).length}件
+          </p>
+        )}
+    </Link>
+  );
+}

--- a/src/components/contexts/ContextForm.tsx
+++ b/src/components/contexts/ContextForm.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useState } from "react";
+import type { ContextType, GlossaryEntry } from "@/types/database";
+import { GlossaryEditor } from "./GlossaryEditor";
+
+interface ContextFormProps {
+  onSubmit: (data: {
+    type: ContextType;
+    title: string;
+    source_url: string;
+    glossary: GlossaryEntry[];
+  }) => void;
+  loading: boolean;
+}
+
+const typeOptions: { value: ContextType; label: string }[] = [
+  { value: "theme_park", label: "テーマパーク" },
+  { value: "museum", label: "博物館" },
+  { value: "theater", label: "演劇" },
+  { value: "other", label: "その他" },
+];
+
+export function ContextForm({ onSubmit, loading }: ContextFormProps) {
+  const [type, setType] = useState<ContextType>("other");
+  const [title, setTitle] = useState("");
+  const [sourceUrl, setSourceUrl] = useState("");
+  const [glossary, setGlossary] = useState<GlossaryEntry[]>([]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onSubmit({ type, title, source_url: sourceUrl, glossary });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      {/* Type selector */}
+      <div>
+        <label className="mb-1 block text-xs font-medium text-text-secondary">
+          種別
+        </label>
+        <div className="flex gap-2">
+          {typeOptions.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => setType(opt.value)}
+              className={`rounded-full px-3 py-1.5 text-xs font-medium transition-colors ${
+                type === opt.value
+                  ? "bg-primary text-primary-foreground"
+                  : "bg-bg-card text-text-secondary"
+              }`}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Title */}
+      <div>
+        <label className="mb-1 block text-xs font-medium text-text-secondary">
+          タイトル *
+        </label>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+          placeholder="例: Haunted Mansion"
+          className="w-full rounded-[10px] border border-border bg-bg-input px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:border-primary focus:outline-none"
+        />
+      </div>
+
+      {/* URL */}
+      <div>
+        <label className="mb-1 block text-xs font-medium text-text-secondary">
+          参考URL（任意）
+        </label>
+        <input
+          type="url"
+          value={sourceUrl}
+          onChange={(e) => setSourceUrl(e.target.value)}
+          placeholder="https://..."
+          className="w-full rounded-[10px] border border-border bg-bg-input px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:border-primary focus:outline-none"
+        />
+      </div>
+
+      {/* Glossary */}
+      <GlossaryEditor glossary={glossary} onChange={setGlossary} />
+
+      {/* Submit */}
+      <button
+        type="submit"
+        disabled={loading || !title.trim()}
+        className="w-full rounded-xl bg-primary py-[13px] text-sm font-semibold text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-50"
+      >
+        {loading ? "作成中..." : "コンテキストを作成"}
+      </button>
+    </form>
+  );
+}

--- a/src/components/contexts/GlossaryEditor.tsx
+++ b/src/components/contexts/GlossaryEditor.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import { useState } from "react";
+import type { GlossaryEntry } from "@/types/database";
+
+const MAX_GLOSSARY_ENTRIES = 20;
+
+interface GlossaryEditorProps {
+  glossary: GlossaryEntry[];
+  onChange: (glossary: GlossaryEntry[]) => void;
+}
+
+export function GlossaryEditor({ glossary, onChange }: GlossaryEditorProps) {
+  const [newEn, setNewEn] = useState("");
+  const [newJa, setNewJa] = useState("");
+
+  const isAtLimit = glossary.length >= MAX_GLOSSARY_ENTRIES;
+
+  const handleAdd = () => {
+    if (!newEn.trim() || !newJa.trim() || isAtLimit) return;
+    onChange([...glossary, { en: newEn.trim(), ja: newJa.trim() }]);
+    setNewEn("");
+    setNewJa("");
+  };
+
+  const handleRemove = (index: number) => {
+    onChange(glossary.filter((_, i) => i !== index));
+  };
+
+  const handleUpdate = (
+    index: number,
+    field: "en" | "ja",
+    value: string,
+  ) => {
+    const updated = [...glossary];
+    updated[index] = { ...updated[index], [field]: value };
+    onChange(updated);
+  };
+
+  return (
+    <div>
+      <div className="mb-2 flex items-center justify-between">
+        <label className="text-xs font-medium text-text-secondary">
+          用語集（{glossary.length}/{MAX_GLOSSARY_ENTRIES}）
+        </label>
+      </div>
+
+      {/* Existing entries */}
+      {glossary.length > 0 && (
+        <div className="mb-3 space-y-2">
+          {glossary.map((entry, index) => (
+            <div key={index} className="flex items-center gap-2">
+              <input
+                type="text"
+                value={entry.en}
+                onChange={(e) => handleUpdate(index, "en", e.target.value)}
+                className="flex-1 rounded-lg border border-border bg-bg-input px-3 py-2 text-xs text-text-primary focus:border-primary focus:outline-none"
+                placeholder="English"
+              />
+              <input
+                type="text"
+                value={entry.ja}
+                onChange={(e) => handleUpdate(index, "ja", e.target.value)}
+                className="flex-1 rounded-lg border border-border bg-bg-input px-3 py-2 text-xs text-text-primary focus:border-primary focus:outline-none"
+                placeholder="日本語"
+              />
+              <button
+                type="button"
+                onClick={() => handleRemove(index)}
+                className="shrink-0 rounded-lg p-1.5 text-text-muted hover:text-destructive"
+              >
+                <svg
+                  width="14"
+                  height="14"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <path d="M18 6 6 18" />
+                  <path d="m6 6 12 12" />
+                </svg>
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Add new entry */}
+      {isAtLimit ? (
+        <p className="text-xs text-warning">
+          用語集の上限（{MAX_GLOSSARY_ENTRIES}件）に達しています
+        </p>
+      ) : (
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={newEn}
+            onChange={(e) => setNewEn(e.target.value)}
+            placeholder="English"
+            className="flex-1 rounded-lg border border-border bg-bg-input px-3 py-2 text-xs text-text-primary placeholder:text-text-muted focus:border-primary focus:outline-none"
+          />
+          <input
+            type="text"
+            value={newJa}
+            onChange={(e) => setNewJa(e.target.value)}
+            placeholder="日本語"
+            className="flex-1 rounded-lg border border-border bg-bg-input px-3 py-2 text-xs text-text-primary placeholder:text-text-muted focus:border-primary focus:outline-none"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleAdd();
+              }
+            }}
+          />
+          <button
+            type="button"
+            onClick={handleAdd}
+            disabled={!newEn.trim() || !newJa.trim()}
+            className="shrink-0 rounded-lg bg-primary p-1.5 text-primary-foreground disabled:opacity-50"
+          >
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M5 12h14" />
+              <path d="M12 5v14" />
+            </svg>
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/contexts/TemplatePicker.tsx
+++ b/src/components/contexts/TemplatePicker.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useState, useEffect, useMemo } from "react";
+import { createClient } from "@/lib/supabase/client";
+import type { ContextTemplate } from "@/types/database";
+
+interface TemplatePickerProps {
+  onSelect: (templateId: string) => void;
+  loading: boolean;
+}
+
+export function TemplatePicker({ onSelect, loading }: TemplatePickerProps) {
+  const [templates, setTemplates] = useState<ContextTemplate[]>([]);
+  const [search, setSearch] = useState("");
+  const [fetchLoading, setFetchLoading] = useState(true);
+
+  const supabase = createClient();
+
+  useEffect(() => {
+    async function fetchTemplates() {
+      const { data } = await supabase
+        .from("context_templates")
+        .select("*")
+        .order("sort_order", { ascending: true });
+      if (data) setTemplates(data);
+      setFetchLoading(false);
+    }
+    fetchTemplates();
+  }, [supabase]);
+
+  const grouped = useMemo(() => {
+    const filtered = templates.filter(
+      (t) =>
+        t.title.toLowerCase().includes(search.toLowerCase()) ||
+        t.park.toLowerCase().includes(search.toLowerCase()),
+    );
+    const groups: Record<string, ContextTemplate[]> = {};
+    for (const t of filtered) {
+      if (!groups[t.park]) groups[t.park] = [];
+      groups[t.park].push(t);
+    }
+    return groups;
+  }, [templates, search]);
+
+  if (fetchLoading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <input
+        type="text"
+        placeholder="テンプレートを検索..."
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        className="w-full rounded-[10px] border border-border bg-bg-input px-4 py-3 text-sm text-text-primary placeholder:text-text-muted focus:border-primary focus:outline-none"
+      />
+
+      {Object.entries(grouped).map(([park, items]) => (
+        <div key={park}>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-muted">
+            {park}
+          </h3>
+          <div className="grid grid-cols-2 gap-2">
+            {items.map((template) => (
+              <button
+                key={template.id}
+                onClick={() => onSelect(template.id)}
+                disabled={loading}
+                className="rounded-lg border border-border bg-bg-card p-3 text-left transition-colors hover:border-primary hover:bg-primary/5 disabled:opacity-50"
+              >
+                <p className="text-sm font-medium text-text-primary">
+                  {template.title}
+                </p>
+                {template.description && (
+                  <p className="mt-1 line-clamp-2 text-xs text-text-muted">
+                    {template.description}
+                  </p>
+                )}
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+
+      {Object.keys(grouped).length === 0 && (
+        <p className="py-8 text-center text-sm text-text-muted">
+          テンプレートが見つかりません
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/stores/contextStore.ts
+++ b/src/stores/contextStore.ts
@@ -1,0 +1,44 @@
+import { create } from "zustand";
+import type { Context, ContextTemplate } from "@/types/database";
+
+interface ContextState {
+  contexts: Context[];
+  templates: ContextTemplate[];
+  total: number;
+  loading: boolean;
+  setContexts: (contexts: Context[], total: number) => void;
+  addContext: (context: Context) => void;
+  updateContext: (context: Context) => void;
+  removeContext: (id: string) => void;
+  appendContexts: (contexts: Context[]) => void;
+  setTemplates: (templates: ContextTemplate[]) => void;
+  setLoading: (loading: boolean) => void;
+}
+
+export const useContextStore = create<ContextState>((set) => ({
+  contexts: [],
+  templates: [],
+  total: 0,
+  loading: false,
+  setContexts: (contexts, total) => set({ contexts, total }),
+  addContext: (context) =>
+    set((state) => ({
+      contexts: [context, ...state.contexts],
+      total: state.total + 1,
+    })),
+  updateContext: (context) =>
+    set((state) => ({
+      contexts: state.contexts.map((c) => (c.id === context.id ? context : c)),
+    })),
+  removeContext: (id) =>
+    set((state) => ({
+      contexts: state.contexts.filter((c) => c.id !== id),
+      total: state.total - 1,
+    })),
+  appendContexts: (contexts) =>
+    set((state) => ({
+      contexts: [...state.contexts, ...contexts],
+    })),
+  setTemplates: (templates) => set({ templates }),
+  setLoading: (loading) => set({ loading }),
+}));

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -28,6 +28,7 @@ export type Database = {
           created_at?: string;
           updated_at?: string;
         };
+        Relationships: [];
       };
       contexts: {
         Row: {
@@ -72,6 +73,7 @@ export type Database = {
           created_at?: string;
           updated_at?: string;
         };
+        Relationships: [];
       };
       sessions: {
         Row: {
@@ -104,6 +106,7 @@ export type Database = {
           ended_at?: string | null;
           created_at?: string;
         };
+        Relationships: [];
       };
       transcripts: {
         Row: {
@@ -133,6 +136,7 @@ export type Database = {
           timestamp_ms?: number;
           created_at?: string;
         };
+        Relationships: [];
       };
       context_templates: {
         Row: {
@@ -174,8 +178,10 @@ export type Database = {
           created_at?: string;
           updated_at?: string;
         };
+        Relationships: [];
       };
     };
+    Views: Record<string, never>;
     Functions: {
       get_monthly_usage: {
         Args: {


### PR DESCRIPTION
## Summary
- テンプレート一覧/詳細/使用API（GET /api/templates, POST /api/templates/:id/use）
- コンテキストCRUD API（Zodバリデーション、offset-basedページネーション）
- テンプレート選択UI（パーク別グループ化、検索機能）
- コンテキスト手動作成フォーム（種別選択器）
- 用語集エディタ（追加/編集/削除、最大20件制限）
- コンテキスト一覧画面（FAB + ページネーション）
- コンテキスト新規作成画面（テンプレート/手動タブ切替）
- コンテキスト詳細画面（編集・保存・削除・翻訳開始ボタン）
- Context Zustand ストア
- Database型修正（Supabase SDK互換性向上）

## Sprint 2 タスク
- [x] #23 テンプレート一覧API
- [x] #24 テンプレート詳細API
- [x] #25 テンプレートからコンテキスト作成API
- [x] #26 コンテキストCRUD API
- [x] #27 テンプレート選択UI
- [x] #28 コンテキスト登録画面
- [x] #29 コンテキスト手動作成フォーム
- [x] #30 コンテキスト一覧画面
- [x] #31 コンテキストカード
- [x] #32 コンテキスト詳細・編集画面
- [x] #33 用語集エディタ
- [x] #34 コンテキスト状態管理ストア

## Test plan
- [x] `pnpm build` 成功
- [x] `pnpm type-check` パス
- [x] 全14ルートが正常生成

🤖 Generated with [Claude Code](https://claude.com/claude-code)