### PR TITLE
feat: add template and context CRUD API endpoints

### DIFF
--- a/src/app/api/contexts/[id]/route.ts
+++ b/src/app/api/contexts/[id]/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod/v4';
+import { getAuthUser } from '@/lib/auth';
+
+const updateContextSchema = z.object({
+  title: z.string().min(1).max(100).optional(),
+  context_type: z.enum(['theme_park', 'museum', 'theater', 'other']).optional(),
+  source_url: z.url().nullable().optional(),
+  description: z.string().nullable().optional(),
+  glossary: z
+    .array(z.object({ en: z.string(), ja: z.string() }))
+    .max(20)
+    .optional(),
+  keywords: z.array(z.string()).optional(),
+});
+
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { supabase } = await getAuthUser();
+    const { id } = await params;
+
+    const { data, error } = await supabase
+      .from('contexts')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return NextResponse.json({ error: 'Context not found' }, { status: 404 });
+      }
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(data);
+  } catch (e) {
+    if (e instanceof Response) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function PUT(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { supabase } = await getAuthUser();
+    const { id } = await params;
+    const body = await request.json();
+    const parsed = updateContextSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.issues }, { status: 400 });
+    }
+
+    const updates: Record<string, unknown> = {};
+    const { title, context_type, source_url, description, glossary, keywords } = parsed.data;
+
+    if (title !== undefined) updates.title = title;
+    if (context_type !== undefined) updates.context_type = context_type;
+    if (source_url !== undefined) updates.source_url = source_url;
+    if (description !== undefined) updates.description = description;
+    if (glossary !== undefined) {
+      updates.glossary = glossary;
+      // Auto-derive keywords from glossary if keywords not explicitly provided
+      if (keywords === undefined) {
+        updates.keywords = glossary.map((g) => g.en).filter((k) => k.length > 0);
+      }
+    }
+    if (keywords !== undefined) updates.keywords = keywords;
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json({ error: 'No fields to update' }, { status: 400 });
+    }
+
+    const { data, error } = await supabase
+      .from('contexts')
+      .update(updates)
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return NextResponse.json({ error: 'Context not found' }, { status: 404 });
+      }
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(data);
+  } catch (e) {
+    if (e instanceof Response) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { supabase } = await getAuthUser();
+    const { id } = await params;
+
+    const { error } = await supabase.from('contexts').delete().eq('id', id);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return new Response(null, { status: 204 });
+  } catch (e) {
+    if (e instanceof Response) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/contexts/route.ts
+++ b/src/app/api/contexts/route.ts
@@ -1,0 +1,87 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod/v4';
+import { getAuthUser } from '@/lib/auth';
+
+const createContextSchema = z.object({
+  title: z.string().min(1).max(100),
+  context_type: z.enum(['theme_park', 'museum', 'theater', 'other']).default('other'),
+  source_url: z.url().nullable().optional(),
+  description: z.string().nullable().optional(),
+  glossary: z
+    .array(z.object({ en: z.string(), ja: z.string() }))
+    .max(20)
+    .default([]),
+  keywords: z.array(z.string()).default([]),
+});
+
+export async function GET(request: Request) {
+  try {
+    const { supabase } = await getAuthUser();
+    const { searchParams } = new URL(request.url);
+    const limit = Math.min(Number(searchParams.get('limit') ?? 20), 50);
+    const offset = Math.max(Number(searchParams.get('offset') ?? 0), 0);
+
+    const { data, error, count } = await supabase
+      .from('contexts')
+      .select('*', { count: 'exact' })
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ data, total: count ?? 0 });
+  } catch (e) {
+    if (e instanceof Response) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const { supabase, user } = await getAuthUser();
+    const body = await request.json();
+    const parsed = createContextSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.issues }, { status: 400 });
+    }
+
+    const { title, context_type, source_url, description, glossary, keywords } = parsed.data;
+
+    // Extract keywords from glossary EN terms if not provided
+    const derivedKeywords =
+      keywords.length > 0
+        ? keywords
+        : glossary.map((g) => g.en).filter((k) => k.length > 0);
+
+    const { data, error } = await supabase
+      .from('contexts')
+      .insert({
+        user_id: user.id,
+        title,
+        context_type,
+        status: 'ready',
+        source_url: source_url ?? null,
+        description: description ?? null,
+        glossary,
+        keywords: derivedKeywords,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(data, { status: 201 });
+  } catch (e) {
+    if (e instanceof Response) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/templates/[id]/route.ts
+++ b/src/app/api/templates/[id]/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { getAuthUser } from '@/lib/auth';
+
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { supabase } = await getAuthUser();
+    const { id } = await params;
+
+    const { data, error } = await supabase
+      .from('context_templates')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return NextResponse.json({ error: 'Template not found' }, { status: 404 });
+      }
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(data);
+  } catch (e) {
+    if (e instanceof Response) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/templates/[id]/use/route.ts
+++ b/src/app/api/templates/[id]/use/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from 'next/server';
+import { getAuthUser } from '@/lib/auth';
+
+export async function POST(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { supabase, user } = await getAuthUser();
+    const { id } = await params;
+
+    // Fetch the template
+    const { data: template, error: templateError } = await supabase
+      .from('context_templates')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (templateError) {
+      if (templateError.code === 'PGRST116') {
+        return NextResponse.json({ error: 'Template not found' }, { status: 404 });
+      }
+      return NextResponse.json({ error: templateError.message }, { status: 500 });
+    }
+
+    // Create context from template
+    const { data: context, error: insertError } = await supabase
+      .from('contexts')
+      .insert({
+        user_id: user.id,
+        title: template.title,
+        context_type: template.context_type,
+        status: 'ready',
+        description: template.description,
+        glossary: template.glossary,
+        keywords: template.keywords,
+        metadata: template.metadata,
+        template_id: template.id,
+      })
+      .select()
+      .single();
+
+    if (insertError) {
+      return NextResponse.json({ error: insertError.message }, { status: 500 });
+    }
+
+    return NextResponse.json(context, { status: 201 });
+  } catch (e) {
+    if (e instanceof Response) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/templates/route.ts
+++ b/src/app/api/templates/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { getAuthUser } from '@/lib/auth';
+
+export async function GET() {
+  try {
+    const { supabase } = await getAuthUser();
+
+    const { data, error } = await supabase
+      .from('context_templates')
+      .select('id, title, context_type, park_name, glossary, keywords, sort_order')
+      .order('sort_order', { ascending: true });
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(data);
+  } catch (e) {
+    if (e instanceof Response) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## Summary

- **Template API**: List, detail, and use-template-to-create-context endpoints
- **Context CRUD API**: Create, read (with pagination), update, delete endpoints
- All endpoints authenticated via `getAuthUser()` + Supabase RLS
- Request validation with Zod for context creation/update
- Keywords auto-derived from glossary EN terms

## Sprint 2 Tasks

- 2-1: テンプレート一覧API（sort_order昇順ソート）
- 2-2: テンプレート詳細API（description含むレスポンス）
- 2-3: テンプレートからコンテキスト作成API
- 2-4: コンテキスト CRUD API（offset-based pagination）

Closes #89
Closes #90

## Test plan

- [ ] GET /api/templates returns templates sorted by sort_order
- [ ] GET /api/templates/[id] returns template with description
- [ ] POST /api/templates/[id]/use creates context from template with copied glossary/keywords
- [ ] GET /api/contexts returns paginated list with total count
- [ ] POST /api/contexts validates input and creates context
- [ ] PUT /api/contexts/[id] updates specified fields
- [ ] DELETE /api/contexts/[id] removes context
- [ ] Unauthenticated requests return 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)