### PR TITLE
feat: add context management UI (list, create, detail, edit)

### DIFF
--- a/src/app/(app)/contexts/[id]/page.tsx
+++ b/src/app/(app)/contexts/[id]/page.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useParams } from 'next/navigation';
+import Link from 'next/link';
+import { ContextForm } from '@/components/contexts/ContextForm';
+
+const typeConfig: Record<string, { icon: string; label: string }> = {
+  theme_park: { icon: '\u{1F3F0}', label: 'テーマパーク' },
+  museum: { icon: '\u{1F3DB}\uFE0F', label: '博物館' },
+  theater: { icon: '\u{1F3AD}', label: '演劇' },
+  other: { icon: '\u{1F4C4}', label: 'その他' },
+};
+
+interface ContextData {
+  id: string;
+  title: string;
+  context_type: 'theme_park' | 'museum' | 'theater' | 'other';
+  source_url: string | null;
+  glossary: { en: string; ja: string }[];
+  created_at: string;
+}
+
+export default function ContextDetailPage() {
+  const router = useRouter();
+  const { id } = useParams<{ id: string }>();
+  const [context, setContext] = useState<ContextData | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const [saveMessage, setSaveMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(`/api/contexts/${id}`)
+      .then((res) => {
+        if (!res.ok) throw new Error('Not found');
+        return res.json();
+      })
+      .then((data) => {
+        setContext(data);
+        setIsLoading(false);
+      })
+      .catch(() => {
+        router.replace('/contexts');
+      });
+  }, [id, router]);
+
+  const handleDelete = async () => {
+    setIsDeleting(true);
+    const res = await fetch(`/api/contexts/${id}`, { method: 'DELETE' });
+    if (res.ok) {
+      router.replace('/contexts');
+    }
+    setIsDeleting(false);
+  };
+
+  if (isLoading || !context) {
+    return (
+      <div className="flex items-center justify-center py-24">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  const config = typeConfig[context.context_type] ?? typeConfig.other;
+
+  return (
+    <div className="mx-auto max-w-lg">
+      {/* Sub-header */}
+      <div className="flex items-center border-b border-border px-4 py-3">
+        <Link href="/contexts" className="text-sm text-muted-foreground hover:text-foreground">
+          ← 戻る
+        </Link>
+        <span className="flex-1 text-center text-sm font-medium">コンテキスト詳細</span>
+        <div className="w-10" />
+      </div>
+
+      <div className="p-4">
+        {/* Header info */}
+        <div className="mb-6">
+          <h1 className="text-xl font-semibold">{context.title}</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            {config.icon} {config.label}
+          </p>
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            作成日: {new Date(context.created_at).toLocaleDateString('ja-JP')}
+          </p>
+        </div>
+
+        <div className="border-t border-border pt-6">
+          {/* Edit form */}
+          <ContextForm
+            mode="edit"
+            contextId={context.id}
+            initialValues={{
+              title: context.title,
+              context_type: context.context_type,
+              source_url: context.source_url,
+              glossary: Array.isArray(context.glossary) ? context.glossary : [],
+            }}
+            onSaved={() => {
+              setSaveMessage('変更を保存しました');
+              setTimeout(() => setSaveMessage(null), 3000);
+            }}
+          />
+
+          {saveMessage && (
+            <p className="mt-3 text-center text-sm text-success">{saveMessage}</p>
+          )}
+
+          {/* Start translation with this context */}
+          <Link
+            href={`/live?contextId=${context.id}`}
+            className="mt-4 flex h-[52px] w-full items-center justify-center gap-2 rounded-xl border border-primary text-sm font-medium text-primary transition-colors hover:bg-accent"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="18"
+              height="18"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            >
+              <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+              <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+              <line x1="12" x2="12" y1="19" y2="22" />
+            </svg>
+            このコンテキストで翻訳開始
+          </Link>
+
+          {/* Delete */}
+          <button
+            onClick={() => setShowDeleteConfirm(true)}
+            className="mt-4 w-full py-3 text-center text-sm text-destructive"
+          >
+            このコンテキストを削除
+          </button>
+        </div>
+      </div>
+
+      {/* Delete confirmation dialog */}
+      {showDeleteConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-sm rounded-2xl bg-background p-6">
+            <h3 className="text-lg font-semibold">本当に削除しますか？</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              「{context.title}」を削除すると元に戻せません。
+            </p>
+            <div className="mt-6 flex gap-3">
+              <button
+                onClick={() => setShowDeleteConfirm(false)}
+                className="flex-1 rounded-xl border border-border py-3 text-sm font-medium"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={handleDelete}
+                disabled={isDeleting}
+                className="flex-1 rounded-xl bg-destructive py-3 text-sm font-medium text-white disabled:opacity-50"
+              >
+                {isDeleting ? '削除中...' : '削除する'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/contexts/new/page.tsx
+++ b/src/app/(app)/contexts/new/page.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { TemplatePicker } from '@/components/contexts/TemplatePicker';
+import { ContextForm } from '@/components/contexts/ContextForm';
+
+type Tab = 'template' | 'manual';
+
+export default function NewContextPage() {
+  const [tab, setTab] = useState<Tab>('template');
+
+  return (
+    <div className="mx-auto max-w-lg">
+      {/* Sub-header */}
+      <div className="flex items-center border-b border-border px-4 py-3">
+        <Link href="/contexts" className="text-sm text-muted-foreground hover:text-foreground">
+          ← 戻る
+        </Link>
+        <span className="flex-1 text-center text-sm font-medium">コンテキスト作成</span>
+        <div className="w-10" />
+      </div>
+
+      <div className="p-4">
+        {/* Tab switcher */}
+        <div className="mb-6 flex rounded-[22px] bg-muted p-1">
+          <button
+            onClick={() => setTab('template')}
+            className={`flex-1 rounded-[18px] py-2.5 text-sm font-medium transition-colors ${
+              tab === 'template' ? 'bg-background shadow-sm' : 'text-muted-foreground'
+            }`}
+          >
+            テンプレート
+          </button>
+          <button
+            onClick={() => setTab('manual')}
+            className={`flex-1 rounded-[18px] py-2.5 text-sm font-medium transition-colors ${
+              tab === 'manual' ? 'bg-background shadow-sm' : 'text-muted-foreground'
+            }`}
+          >
+            手動作成
+          </button>
+        </div>
+
+        {/* Tab content */}
+        {tab === 'template' ? <TemplatePicker /> : <ContextForm mode="create" />}
+      </div>
+    </div>
+  );
+}

--- a/src/app/(app)/contexts/page.tsx
+++ b/src/app/(app)/contexts/page.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { ContextCard } from '@/components/contexts/ContextCard';
+
+interface Context {
+  id: string;
+  title: string;
+  context_type: 'theme_park' | 'museum' | 'theater' | 'other';
+  glossary: { en: string; ja: string }[];
+  template_id: string | null;
+}
+
+export default function ContextsPage() {
+  const [contexts, setContexts] = useState<Context[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [total, setTotal] = useState(0);
+  const [offset, setOffset] = useState(0);
+  const limit = 20;
+
+  useEffect(() => {
+    setIsLoading(true);
+    fetch(`/api/contexts?limit=${limit}&offset=${offset}`)
+      .then((res) => res.json())
+      .then((result) => {
+        if (offset === 0) {
+          setContexts(result.data ?? []);
+        } else {
+          setContexts((prev) => [...prev, ...(result.data ?? [])]);
+        }
+        setTotal(result.total ?? 0);
+        setIsLoading(false);
+      });
+  }, [offset]);
+
+  return (
+    <div className="mx-auto max-w-lg p-4">
+      <h1 className="mb-4 text-lg font-semibold">マイコンテキスト</h1>
+
+      {isLoading && contexts.length === 0 ? (
+        <div className="flex items-center justify-center py-12">
+          <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+        </div>
+      ) : contexts.length === 0 ? (
+        <div className="flex flex-col items-center py-12 text-center">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="48"
+            height="48"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className="text-muted-foreground/50"
+          >
+            <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z" />
+            <path d="M14 2v4a2 2 0 0 0 2 2h4" />
+          </svg>
+          <p className="mt-4 text-sm text-muted-foreground">
+            コンテキストがありません。
+            <br />
+            コンテキストを作成して、翻訳精度を向上させましょう。
+          </p>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {contexts.map((ctx) => (
+            <ContextCard key={ctx.id} {...ctx} />
+          ))}
+          {contexts.length < total && (
+            <button
+              onClick={() => setOffset((prev) => prev + limit)}
+              disabled={isLoading}
+              className="w-full py-3 text-center text-sm text-primary"
+            >
+              {isLoading ? '読み込み中...' : 'もっと見る'}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* FAB */}
+      <Link
+        href="/contexts/new"
+        className="fixed bottom-20 right-4 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-2xl text-primary-foreground shadow-lg transition-transform hover:scale-105"
+        aria-label="新規作成"
+      >
+        +
+      </Link>
+    </div>
+  );
+}

--- a/src/components/contexts/ContextCard.tsx
+++ b/src/components/contexts/ContextCard.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link';
+
+interface ContextCardProps {
+  id: string;
+  title: string;
+  context_type: 'theme_park' | 'museum' | 'theater' | 'other';
+  glossary: { en: string; ja: string }[];
+  template_id: string | null;
+}
+
+const typeConfig: Record<string, { icon: string; label: string }> = {
+  theme_park: { icon: '\u{1F3F0}', label: 'テーマパーク' },
+  museum: { icon: '\u{1F3DB}\uFE0F', label: '博物館' },
+  theater: { icon: '\u{1F3AD}', label: '演劇' },
+  other: { icon: '\u{1F4C4}', label: 'その他' },
+};
+
+export function ContextCard({ id, title, context_type, glossary, template_id }: ContextCardProps) {
+  const config = typeConfig[context_type] ?? typeConfig.other;
+  const glossaryCount = Array.isArray(glossary) ? glossary.length : 0;
+
+  return (
+    <Link
+      href={`/contexts/${id}`}
+      className="block rounded-xl bg-card p-4 transition-colors hover:bg-accent"
+    >
+      <p className="font-medium">{title}</p>
+      <p className="mt-1 text-sm text-muted-foreground">
+        {config.icon} {config.label} · 用語{glossaryCount}件
+      </p>
+      <p className="mt-0.5 text-xs text-muted-foreground">
+        {template_id ? 'テンプレートから作成' : '手動作成'}
+      </p>
+    </Link>
+  );
+}

--- a/src/components/contexts/ContextForm.tsx
+++ b/src/components/contexts/ContextForm.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { GlossaryEditor, type GlossaryEntry } from './GlossaryEditor';
+
+type ContextType = 'theme_park' | 'museum' | 'theater' | 'other';
+
+const contextTypes: { value: ContextType; label: string }[] = [
+  { value: 'theme_park', label: 'テーマパーク' },
+  { value: 'museum', label: '博物館' },
+  { value: 'theater', label: '演劇' },
+  { value: 'other', label: 'その他' },
+];
+
+interface ContextFormProps {
+  mode: 'create' | 'edit';
+  initialValues?: {
+    title: string;
+    context_type: ContextType;
+    source_url: string | null;
+    glossary: GlossaryEntry[];
+  };
+  contextId?: string;
+  onSaved?: () => void;
+}
+
+export function ContextForm({ mode, initialValues, contextId, onSaved }: ContextFormProps) {
+  const router = useRouter();
+  const [title, setTitle] = useState(initialValues?.title ?? '');
+  const [contextType, setContextType] = useState<ContextType>(
+    initialValues?.context_type ?? 'other',
+  );
+  const [sourceUrl, setSourceUrl] = useState(initialValues?.source_url ?? '');
+  const [glossary, setGlossary] = useState<GlossaryEntry[]>(initialValues?.glossary ?? []);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setIsSubmitting(true);
+
+    const payload = {
+      title,
+      context_type: contextType,
+      source_url: sourceUrl || null,
+      glossary,
+    };
+
+    const url = mode === 'create' ? '/api/contexts' : `/api/contexts/${contextId}`;
+    const method = mode === 'create' ? 'POST' : 'PUT';
+
+    const res = await fetch(url, {
+      method,
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok) {
+      const data = await res.json();
+      setError(data.error ?? 'エラーが発生しました');
+      setIsSubmitting(false);
+      return;
+    }
+
+    if (mode === 'create') {
+      const created = await res.json();
+      router.push(`/contexts/${created.id}`);
+    } else {
+      onSaved?.();
+    }
+
+    setIsSubmitting(false);
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-5">
+      {/* Context type segment control */}
+      <div>
+        <label className="mb-2 block text-sm font-medium">コンテンツ種別</label>
+        <div className="flex rounded-[22px] bg-muted p-1">
+          {contextTypes.map((ct) => (
+            <button
+              key={ct.value}
+              type="button"
+              onClick={() => setContextType(ct.value)}
+              className={`flex-1 rounded-[18px] py-2 text-xs font-medium transition-colors ${
+                contextType === ct.value
+                  ? 'bg-background shadow-sm'
+                  : 'text-muted-foreground'
+              }`}
+            >
+              {ct.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Title */}
+      <div>
+        <label htmlFor="title" className="mb-1 block text-sm font-medium">
+          タイトル *
+        </label>
+        <input
+          id="title"
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          required
+          maxLength={100}
+          className="bg-input border-border h-12 w-full rounded-xl border px-4 text-sm outline-none focus:ring-2 focus:ring-primary"
+          placeholder="例: Haunted Mansion"
+        />
+      </div>
+
+      {/* Source URL */}
+      <div>
+        <label htmlFor="sourceUrl" className="mb-1 block text-sm font-medium">
+          URL（任意）
+        </label>
+        <input
+          id="sourceUrl"
+          type="url"
+          value={sourceUrl}
+          onChange={(e) => setSourceUrl(e.target.value)}
+          className="bg-input border-border h-12 w-full rounded-xl border px-4 text-sm outline-none focus:ring-2 focus:ring-primary"
+          placeholder="https://..."
+        />
+        <p className="mt-1 text-xs text-muted-foreground">※ Phase 2でAI自動調査に使用</p>
+      </div>
+
+      {/* Glossary */}
+      <div>
+        <label className="mb-2 block text-sm font-medium">用語集</label>
+        <GlossaryEditor entries={glossary} onChange={setGlossary} />
+      </div>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      {/* Submit */}
+      <button
+        type="submit"
+        disabled={isSubmitting || !title.trim()}
+        className="flex h-[52px] w-full items-center justify-center rounded-xl bg-primary text-sm font-medium text-primary-foreground transition-opacity disabled:opacity-50"
+      >
+        {isSubmitting ? (
+          <div className="h-5 w-5 animate-spin rounded-full border-2 border-primary-foreground border-t-transparent" />
+        ) : mode === 'create' ? (
+          '作成する'
+        ) : (
+          '保存する'
+        )}
+      </button>
+    </form>
+  );
+}

--- a/src/components/contexts/GlossaryEditor.tsx
+++ b/src/components/contexts/GlossaryEditor.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState } from 'react';
+
+export interface GlossaryEntry {
+  en: string;
+  ja: string;
+}
+
+interface GlossaryEditorProps {
+  entries: GlossaryEntry[];
+  onChange: (entries: GlossaryEntry[]) => void;
+  maxEntries?: number;
+}
+
+export function GlossaryEditor({ entries, onChange, maxEntries = 20 }: GlossaryEditorProps) {
+  const [en, setEn] = useState('');
+  const [ja, setJa] = useState('');
+
+  const handleAdd = () => {
+    if (!en.trim() || !ja.trim()) return;
+    if (entries.length >= maxEntries) return;
+    onChange([...entries, { en: en.trim(), ja: ja.trim() }]);
+    setEn('');
+    setJa('');
+  };
+
+  const handleRemove = (index: number) => {
+    onChange(entries.filter((_, i) => i !== index));
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleAdd();
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={en}
+          onChange={(e) => setEn(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="EN"
+          className="bg-input border-border h-10 flex-1 rounded-lg border px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+        />
+        <input
+          type="text"
+          value={ja}
+          onChange={(e) => setJa(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="JA"
+          className="bg-input border-border h-10 flex-1 rounded-lg border px-3 text-sm outline-none focus:ring-2 focus:ring-primary"
+        />
+        <button
+          type="button"
+          onClick={handleAdd}
+          disabled={!en.trim() || !ja.trim() || entries.length >= maxEntries}
+          className="h-10 rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground transition-opacity disabled:opacity-50"
+        >
+          追加
+        </button>
+      </div>
+
+      {entries.length >= maxEntries && (
+        <p className="text-xs text-muted-foreground">用語は最大{maxEntries}件まで登録できます</p>
+      )}
+
+      {entries.length > 0 && (
+        <div className="space-y-1">
+          {entries.map((entry, i) => (
+            <div
+              key={i}
+              className="flex items-center justify-between rounded-lg bg-card px-3 py-2 text-sm"
+            >
+              <span>
+                {entry.en} → {entry.ja}
+              </span>
+              <button
+                type="button"
+                onClick={() => handleRemove(i)}
+                className="ml-2 text-muted-foreground hover:text-destructive"
+              >
+                ×
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/contexts/TemplatePicker.tsx
+++ b/src/components/contexts/TemplatePicker.tsx
@@ -1,0 +1,133 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface Template {
+  id: string;
+  title: string;
+  context_type: string;
+  park_name: string | null;
+  glossary: { en: string; ja: string }[];
+  keywords: string[];
+  sort_order: number;
+}
+
+export function TemplatePicker() {
+  const router = useRouter();
+  const [templates, setTemplates] = useState<Template[]>([]);
+  const [search, setSearch] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
+  const [confirmTemplate, setConfirmTemplate] = useState<Template | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/templates')
+      .then((res) => res.json())
+      .then((data) => {
+        setTemplates(data);
+        setIsLoading(false);
+      });
+  }, []);
+
+  const filtered = templates.filter((t) =>
+    t.title.toLowerCase().includes(search.toLowerCase()),
+  );
+
+  // Group by park
+  const grouped = filtered.reduce<Record<string, Template[]>>((acc, t) => {
+    const park = t.park_name ?? 'その他';
+    if (!acc[park]) acc[park] = [];
+    acc[park].push(t);
+    return acc;
+  }, {});
+
+  const handleUseTemplate = async (template: Template) => {
+    setIsCreating(true);
+    const res = await fetch(`/api/templates/${template.id}/use`, { method: 'POST' });
+    if (res.ok) {
+      const context = await res.json();
+      router.push(`/contexts/${context.id}`);
+    }
+    setIsCreating(false);
+    setConfirmTemplate(null);
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-12">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Search */}
+      <input
+        type="text"
+        value={search}
+        onChange={(e) => setSearch(e.target.value)}
+        placeholder="テンプレートを検索..."
+        className="bg-input border-border h-12 w-full rounded-xl border px-4 text-sm outline-none focus:ring-2 focus:ring-primary"
+      />
+
+      {/* Template groups */}
+      {Object.entries(grouped).map(([park, parkTemplates]) => (
+        <div key={park}>
+          <h3 className="mb-2 text-sm font-medium text-muted-foreground">{park}</h3>
+          <div className="grid grid-cols-2 gap-3">
+            {parkTemplates.map((t) => (
+              <button
+                key={t.id}
+                onClick={() => setConfirmTemplate(t)}
+                className="rounded-xl bg-card p-3 text-left transition-colors hover:bg-accent"
+              >
+                <p className="text-sm font-medium leading-tight">{t.title}</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  用語{Array.isArray(t.glossary) ? t.glossary.length : 0}件
+                </p>
+              </button>
+            ))}
+          </div>
+        </div>
+      ))}
+
+      {filtered.length === 0 && (
+        <p className="py-8 text-center text-sm text-muted-foreground">
+          テンプレートが見つかりません
+        </p>
+      )}
+
+      {/* Confirmation dialog */}
+      {confirmTemplate && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-sm rounded-2xl bg-background p-6">
+            <h3 className="text-lg font-semibold">「{confirmTemplate.title}」を追加</h3>
+            <div className="mt-3 space-y-1 text-sm text-muted-foreground">
+              <p>
+                用語集: {Array.isArray(confirmTemplate.glossary) ? confirmTemplate.glossary.length : 0}件
+              </p>
+              <p>キーワード: {confirmTemplate.keywords?.length ?? 0}件</p>
+            </div>
+            <div className="mt-6 flex gap-3">
+              <button
+                onClick={() => setConfirmTemplate(null)}
+                className="flex-1 rounded-xl border border-border py-3 text-sm font-medium"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={() => handleUseTemplate(confirmTemplate)}
+                disabled={isCreating}
+                className="flex-1 rounded-xl bg-primary py-3 text-sm font-medium text-primary-foreground disabled:opacity-50"
+              >
+                {isCreating ? '作成中...' : 'コンテキストに追加'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Context list page** (`/contexts`): Empty state, pagination with "load more", FAB for new context
- **Context creation page** (`/contexts/new`): Tab-switched template picker and manual form
- **Template picker**: Park-grouped templates with search, confirmation dialog before use
- **Context detail/edit page** (`/contexts/[id]`): Inline edit form, delete with confirmation, "start translation with this context" link
- **Reusable components**: ContextForm, ContextCard, GlossaryEditor, TemplatePicker

## Sprint 2 Tasks

- 2-5: テンプレート選択UI（パーク別グルーピング + 検索）
- 2-6: コンテキスト手動作成フォーム
- 2-7: テンプレート選択確認ダイアログ
- 2-8: コンテキスト一覧画面
- 2-9: コンテキスト詳細・編集画面
- 2-10: 用語集エディタ
- 2-11: コンテキスト削除確認ダイアログ
- 2-12: コンテキストストア更新

Closes #91
Closes #92

## Test plan

- [ ] Context list shows empty state when no contexts exist
- [ ] FAB navigates to /contexts/new
- [ ] Template tab shows templates grouped by park with search
- [ ] Selecting a template shows confirmation dialog
- [ ] Confirming creates context and navigates to detail page
- [ ] Manual form creates context with title, type, URL, glossary
- [ ] Glossary editor adds/removes EN/JA pairs (max 20)
- [ ] Context detail shows edit form with pre-filled values
- [ ] Save button updates context
- [ ] Delete button shows confirmation and deletes on confirm
- [ ] "Start translation" button links to /live with contextId

🤖 Generated with [Claude Code](https://claude.com/claude-code)