### PR TITLE
feat: add Deepgram token, translation SSE, and session APIs

### DIFF
--- a/src/app/api/deepgram-token/route.ts
+++ b/src/app/api/deepgram-token/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import { getAuthUser } from '@/lib/auth';
+
+export async function POST() {
+  try {
+    await getAuthUser();
+
+    const apiKey = process.env.DEEPGRAM_API_KEY;
+    if (!apiKey) {
+      return NextResponse.json({ error: 'Deepgram API key not configured' }, { status: 500 });
+    }
+
+    const res = await fetch('https://api.deepgram.com/v1/auth/grant', {
+      method: 'POST',
+      headers: {
+        Authorization: `Token ${apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        time_to_live_in_seconds: 600,
+      }),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      return NextResponse.json(
+        { error: `Deepgram token request failed: ${text}` },
+        { status: 502 },
+      );
+    }
+
+    const data = await res.json();
+
+    return NextResponse.json({
+      token: data.access_token ?? data.token,
+      expiresIn: 600,
+    });
+  } catch (e) {
+    if (e instanceof Response) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/sessions/[id]/route.ts
+++ b/src/app/api/sessions/[id]/route.ts
@@ -1,0 +1,119 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod/v4';
+import { getAuthUser } from '@/lib/auth';
+
+const updateSessionSchema = z.object({
+  endedAt: z.string().optional(),
+  title: z.string().optional(),
+  translationTier: z.enum(['lite', 'standard', 'premium']).optional(),
+});
+
+export async function GET(_request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { supabase } = await getAuthUser();
+    const { id } = await params;
+
+    const { data: session, error: sessionError } = await supabase
+      .from('sessions')
+      .select('*')
+      .eq('id', id)
+      .single();
+
+    if (sessionError) {
+      if (sessionError.code === 'PGRST116') {
+        return NextResponse.json({ error: 'Session not found' }, { status: 404 });
+      }
+      return NextResponse.json({ error: sessionError.message }, { status: 500 });
+    }
+
+    // Also fetch transcripts
+    const { data: transcripts } = await supabase
+      .from('transcripts')
+      .select('*')
+      .eq('session_id', id)
+      .order('timestamp_ms', { ascending: true });
+
+    return NextResponse.json({ ...session, transcripts: transcripts ?? [] });
+  } catch (e) {
+    if (e instanceof Response) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request, { params }: { params: Promise<{ id: string }> }) {
+  try {
+    const { supabase } = await getAuthUser();
+    const { id } = await params;
+    const body = await request.json();
+    const parsed = updateSessionSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.issues }, { status: 400 });
+    }
+
+    const updates: Record<string, unknown> = {};
+    if (parsed.data.endedAt) updates.ended_at = parsed.data.endedAt;
+    if (parsed.data.title) updates.title = parsed.data.title;
+    if (parsed.data.translationTier) updates.translation_tier = parsed.data.translationTier;
+
+    // Calculate duration if ended_at is set
+    if (parsed.data.endedAt) {
+      const { data: session } = await supabase
+        .from('sessions')
+        .select('started_at')
+        .eq('id', id)
+        .single();
+
+      if (session?.started_at) {
+        const duration = Math.round(
+          (new Date(parsed.data.endedAt).getTime() - new Date(session.started_at).getTime()) /
+            1000,
+        );
+        updates.duration_seconds = duration;
+      }
+    }
+
+    const { data, error } = await supabase
+      .from('sessions')
+      .update(updates)
+      .eq('id', id)
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(data);
+  } catch (e) {
+    if (e instanceof Response) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function DELETE(
+  _request: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const { supabase } = await getAuthUser();
+    const { id } = await params;
+
+    const { error } = await supabase.from('sessions').delete().eq('id', id);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return new Response(null, { status: 204 });
+  } catch (e) {
+    if (e instanceof Response) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/sessions/route.ts
+++ b/src/app/api/sessions/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod/v4';
+import { getAuthUser } from '@/lib/auth';
+
+const createSessionSchema = z.object({
+  contextId: z.string().uuid().optional(),
+  title: z.string().optional(),
+  translationTier: z.enum(['lite', 'standard', 'premium']).default('standard'),
+});
+
+export async function GET(request: Request) {
+  try {
+    const { supabase } = await getAuthUser();
+    const { searchParams } = new URL(request.url);
+    const limit = Math.min(Number(searchParams.get('limit') ?? 20), 50);
+    const offset = Math.max(Number(searchParams.get('offset') ?? 0), 0);
+
+    const { data, error, count } = await supabase
+      .from('sessions')
+      .select('*', { count: 'exact' })
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json({ data, total: count ?? 0 });
+  } catch (e) {
+    if (e instanceof Response) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const { supabase, user } = await getAuthUser();
+    const body = await request.json();
+    const parsed = createSessionSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return NextResponse.json({ error: parsed.error.issues }, { status: 400 });
+    }
+
+    const { contextId, title, translationTier } = parsed.data;
+    const now = new Date().toISOString();
+
+    // Auto-generate title if not provided
+    const sessionTitle =
+      title ?? `セッション ${new Date().toLocaleString('ja-JP', { month: 'short', day: 'numeric', hour: '2-digit', minute: '2-digit' })}`;
+
+    const { data, error } = await supabase
+      .from('sessions')
+      .insert({
+        user_id: user.id,
+        context_id: contextId ?? null,
+        title: sessionTitle,
+        translation_tier: translationTier,
+        started_at: now,
+      })
+      .select()
+      .single();
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    return NextResponse.json(data, { status: 201 });
+  } catch (e) {
+    if (e instanceof Response) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/app/api/translate/route.ts
+++ b/src/app/api/translate/route.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod/v4';
+import { getAuthUser } from '@/lib/auth';
+import { translateStream } from '@/lib/translation';
+
+const translateRequestSchema = z.object({
+  utterance: z.string().min(1),
+  sequenceNumber: z.number().int().min(0),
+  context: z
+    .object({
+      title: z.string().optional(),
+      type: z.string().optional(),
+      description: z.string().optional(),
+      glossary: z.array(z.object({ en: z.string(), ja: z.string() })).optional(),
+    })
+    .optional(),
+  history: z
+    .array(z.object({ original: z.string(), translated: z.string() }))
+    .max(3)
+    .optional(),
+  tier: z.enum(['lite', 'standard', 'premium']),
+  sessionId: z.string(),
+});
+
+export async function POST(request: Request) {
+  try {
+    const { supabase } = await getAuthUser();
+    const body = await request.json();
+    const parsed = translateRequestSchema.safeParse(body);
+
+    if (!parsed.success) {
+      return new Response(JSON.stringify({ error: parsed.error.issues }), {
+        status: 400,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+
+    const { utterance, sequenceNumber, context, history, tier, sessionId } = parsed.data;
+
+    const encoder = new TextEncoder();
+    let fullText = '';
+
+    const stream = new ReadableStream({
+      async start(controller) {
+        try {
+          const llmStream = translateStream({
+            utterance,
+            tier,
+            context,
+            history,
+          });
+
+          for await (const chunk of llmStream) {
+            fullText += chunk;
+            controller.enqueue(
+              encoder.encode(
+                `data: ${JSON.stringify({ text: chunk, done: false })}\n\n`,
+              ),
+            );
+          }
+
+          // Save to transcripts before closing (Vercel Hobby constraint)
+          await supabase.from('transcripts').insert({
+            session_id: sessionId,
+            sequence_number: sequenceNumber,
+            original_text: utterance,
+            translated_text: fullText,
+            timestamp_ms: Date.now(),
+            translation_tier: tier,
+          });
+
+          // Send done event
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({
+                text: fullText,
+                done: true,
+                original: utterance,
+                sequenceNumber,
+              })}\n\n`,
+            ),
+          );
+          controller.close();
+        } catch (err) {
+          const errorMessage = err instanceof Error ? err.message : 'Translation failed';
+          controller.enqueue(
+            encoder.encode(
+              `data: ${JSON.stringify({ error: errorMessage, done: true })}\n\n`,
+            ),
+          );
+          controller.close();
+        }
+      },
+    });
+
+    return new Response(stream, {
+      headers: {
+        'Content-Type': 'text/event-stream',
+        'Cache-Control': 'no-cache',
+        Connection: 'keep-alive',
+      },
+    });
+  } catch (e) {
+    if (e instanceof Response) {
+      return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+    return new Response(JSON.stringify({ error: 'Internal server error' }), {
+      status: 500,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}

--- a/src/lib/prompts/translation.ts
+++ b/src/lib/prompts/translation.ts
@@ -1,0 +1,79 @@
+interface GlossaryEntry {
+  en: string;
+  ja: string;
+}
+
+interface HistoryEntry {
+  original: string;
+  translated: string;
+}
+
+interface CompactContext {
+  title?: string;
+  type?: string;
+  glossary?: GlossaryEntry[];
+  description?: string;
+}
+
+interface BuildPromptParams {
+  utterance: string;
+  context?: CompactContext;
+  history?: HistoryEntry[];
+}
+
+export function buildTranslationPrompt({ utterance, context, history }: BuildPromptParams): string {
+  const parts: string[] = [];
+
+  // System instruction
+  parts.push(
+    'You are a real-time English-to-Japanese translator for live subtitle display.',
+    'Translate the following English text into natural, fluent Japanese.',
+    'Output ONLY the Japanese translation, nothing else.',
+    '',
+  );
+
+  // Context section
+  if (context) {
+    parts.push('## Context');
+    if (context.title) parts.push(`Content: ${context.title}`);
+    if (context.type) parts.push(`Type: ${context.type}`);
+    if (context.description) parts.push(`Description: ${context.description}`);
+
+    if (context.glossary && context.glossary.length > 0) {
+      parts.push('', 'Glossary (use these translations for these terms):');
+      for (const entry of context.glossary) {
+        parts.push(`- "${entry.en}" → "${entry.ja}"`);
+      }
+    }
+    parts.push('');
+  }
+
+  // Sliding window history
+  if (history && history.length > 0) {
+    parts.push('## Recent translations (for consistency):');
+    for (const h of history.slice(-3)) {
+      parts.push(`EN: ${h.original}`);
+      parts.push(`JA: ${h.translated}`);
+      parts.push('');
+    }
+  }
+
+  // Current utterance
+  parts.push('## Translate this:');
+  parts.push(utterance);
+
+  return parts.join('\n');
+}
+
+export function buildSystemPrompt(): string {
+  return [
+    'You are a real-time English-to-Japanese translator.',
+    'Your task is to translate spoken English into natural, accurate Japanese for live subtitle display.',
+    'Rules:',
+    '- Output ONLY the Japanese translation text',
+    '- Use natural Japanese (not machine-translated style)',
+    '- Preserve proper nouns as-is unless a glossary translation is provided',
+    '- Keep the translation concise for subtitle readability',
+    '- Maintain consistency with recent translations provided in context',
+  ].join('\n');
+}

--- a/src/lib/translation.ts
+++ b/src/lib/translation.ts
@@ -1,0 +1,155 @@
+import { buildTranslationPrompt, buildSystemPrompt } from '@/lib/prompts/translation';
+
+type TranslationTier = 'lite' | 'standard' | 'premium';
+
+interface TranslateParams {
+  utterance: string;
+  tier: TranslationTier;
+  context?: {
+    title?: string;
+    type?: string;
+    glossary?: { en: string; ja: string }[];
+    description?: string;
+  };
+  history?: { original: string; translated: string }[];
+}
+
+const tierConfig: Record<TranslationTier, { provider: 'gemini' | 'anthropic'; model: string }> = {
+  lite: { provider: 'gemini', model: 'gemini-2.5-flash-lite-preview-06-17' },
+  standard: { provider: 'gemini', model: 'gemini-2.5-flash-preview-05-20' },
+  premium: { provider: 'anthropic', model: 'claude-sonnet-4-5-20250929' },
+};
+
+export async function* translateStream(
+  params: TranslateParams,
+): AsyncGenerator<string, void, unknown> {
+  const config = tierConfig[params.tier];
+  const prompt = buildTranslationPrompt(params);
+  const systemPrompt = buildSystemPrompt();
+
+  if (config.provider === 'gemini') {
+    yield* streamGemini(config.model, systemPrompt, prompt);
+  } else {
+    yield* streamAnthropic(config.model, systemPrompt, prompt);
+  }
+}
+
+async function* streamGemini(
+  model: string,
+  systemPrompt: string,
+  userPrompt: string,
+): AsyncGenerator<string, void, unknown> {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) throw new Error('GEMINI_API_KEY not configured');
+
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${model}:streamGenerateContent?alt=sse&key=${apiKey}`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        system_instruction: { parts: [{ text: systemPrompt }] },
+        contents: [{ role: 'user', parts: [{ text: userPrompt }] }],
+        generationConfig: {
+          temperature: 0.3,
+          maxOutputTokens: 256,
+        },
+      }),
+    },
+  );
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Gemini API error: ${res.status} ${text}`);
+  }
+
+  const reader = res.body?.getReader();
+  if (!reader) throw new Error('No response body');
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      if (!line.startsWith('data: ')) continue;
+      const jsonStr = line.slice(6).trim();
+      if (!jsonStr || jsonStr === '[DONE]') continue;
+
+      try {
+        const parsed = JSON.parse(jsonStr);
+        const text = parsed?.candidates?.[0]?.content?.parts?.[0]?.text;
+        if (text) yield text;
+      } catch {
+        // Skip malformed JSON
+      }
+    }
+  }
+}
+
+async function* streamAnthropic(
+  model: string,
+  systemPrompt: string,
+  userPrompt: string,
+): AsyncGenerator<string, void, unknown> {
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) throw new Error('ANTHROPIC_API_KEY not configured');
+
+  const res = await fetch('https://api.anthropic.com/v1/messages', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'x-api-key': apiKey,
+      'anthropic-version': '2023-06-01',
+    },
+    body: JSON.stringify({
+      model,
+      max_tokens: 256,
+      stream: true,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: userPrompt }],
+      temperature: 0.3,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Anthropic API error: ${res.status} ${text}`);
+  }
+
+  const reader = res.body?.getReader();
+  if (!reader) throw new Error('No response body');
+
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? '';
+
+    for (const line of lines) {
+      if (!line.startsWith('data: ')) continue;
+      const jsonStr = line.slice(6).trim();
+      if (!jsonStr || jsonStr === '[DONE]') continue;
+
+      try {
+        const parsed = JSON.parse(jsonStr);
+        if (parsed.type === 'content_block_delta' && parsed.delta?.text) {
+          yield parsed.delta.text;
+        }
+      } catch {
+        // Skip malformed JSON
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **Deepgram token API**: Temporary token issuance for client WebSocket connection (TTL 600s)
- **Translation API (SSE)**: 3-tier streaming translation (Gemini Flash-Lite → Gemini Flash → Claude Sonnet) with prompt builder including glossary, context, and sliding window
- **Session CRUD API**: Create, list, detail (with transcripts), update, delete
- **Prompt builder**: Constructs translation prompts with glossary injection and conversation history

## Sprint 3 Tasks (Backend)

- 3-1: Deepgram一時トークンAPI
- 3-5: 翻訳API（POST→SSE、ティア切替、3モデル対応）
- 3-6: LLM翻訳クライアント（Gemini 3 Flash / 2.5 FL / Claude Sonnet 4.5）
- 3-7: 翻訳プロンプトテンプレート

## Sprint 4 Tasks (Pre-implemented)

- 4-1 to 4-4: セッション CRUD API

Closes #93
Closes #94
Closes #98

## Test plan

- [ ] POST /api/deepgram-token returns temporary token
- [ ] POST /api/translate streams SSE translation chunks
- [ ] Tier selection routes to correct LLM model
- [ ] Translation prompt includes glossary terms
- [ ] Transcripts saved to DB before SSE close
- [ ] Session CRUD operations work correctly
- [ ] SSE response completes within 10s (Vercel Hobby)

🤖 Generated with [Claude Code](https://claude.com/claude-code)