### PR TITLE
feat: add live translation page with full audio-to-subtitle pipeline

### DIFF
--- a/src/app/(app)/live/page.tsx
+++ b/src/app/(app)/live/page.tsx
@@ -1,0 +1,249 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useAudioCapture } from '@/hooks/useAudioCapture';
+import { useDeepgramLive } from '@/hooks/useDeepgramLive';
+import { useUtteranceBuffer } from '@/hooks/useUtteranceBuffer';
+import { useTranslation } from '@/hooks/useTranslation';
+import { SubtitleDisplay } from '@/components/live/SubtitleDisplay';
+import { LiveControls } from '@/components/live/LiveControls';
+import { ContextSelector } from '@/components/live/ContextSelector';
+import { useLiveStore } from '@/stores/liveStore';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+interface ContextData {
+  id: string;
+  title: string;
+  context_type: string;
+  glossary: { en: string; ja: string }[];
+  keywords: string[];
+}
+
+export default function LivePage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const contextIdParam = searchParams.get('contextId');
+
+  const { isRecording, currentTier, sessionId, setRecording, setSessionId, setCurrentTier, setElapsedSeconds, elapsedSeconds, reset } = useLiveStore();
+  const { defaultTier } = useSettingsStore();
+
+  const [selectedContext, setSelectedContext] = useState<ContextData | null>(null);
+  const [interimText, setInterimText] = useState('');
+  const [showCloseConfirm, setShowCloseConfirm] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const audio = useAudioCapture();
+  const deepgram = useDeepgramLive();
+  const buffer = useUtteranceBuffer();
+  const translation = useTranslation();
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Set initial tier from settings
+  useEffect(() => {
+    if (!isRecording) {
+      setCurrentTier(defaultTier);
+    }
+  }, [defaultTier, isRecording, setCurrentTier]);
+
+  // Load context from URL param
+  useEffect(() => {
+    if (contextIdParam) {
+      fetch(`/api/contexts/${contextIdParam}`)
+        .then((res) => (res.ok ? res.json() : null))
+        .then((data) => {
+          if (data) setSelectedContext(data);
+        });
+    }
+  }, [contextIdParam]);
+
+  // Wire deepgram transcripts to utterance buffer
+  useEffect(() => {
+    deepgram.onTranscript((result) => {
+      if (result.isFinal) {
+        setInterimText('');
+        buffer.addText(result.text, true);
+      } else {
+        setInterimText(result.text);
+      }
+    });
+  }, [deepgram, buffer]);
+
+  // Wire utterance buffer to translation
+  useEffect(() => {
+    buffer.onUtterance((utterance) => {
+      if (!sessionId) return;
+      translation.translate({
+        utterance,
+        tier: currentTier,
+        sessionId,
+        context: selectedContext
+          ? {
+              title: selectedContext.title,
+              type: selectedContext.context_type,
+              glossary: selectedContext.glossary,
+            }
+          : undefined,
+      });
+    });
+  }, [buffer, translation, sessionId, currentTier, selectedContext]);
+
+  const handleStart = useCallback(async () => {
+    setError(null);
+    try {
+      // Create session
+      const res = await fetch('/api/sessions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          contextId: selectedContext?.id,
+          translationTier: currentTier,
+        }),
+      });
+
+      if (!res.ok) throw new Error('Failed to create session');
+      const session = await res.json();
+      setSessionId(session.id);
+
+      // Connect to Deepgram
+      await deepgram.connect(selectedContext?.keywords);
+
+      // Start audio capture
+      await audio.startCapture((data) => deepgram.sendAudio(data));
+
+      setRecording(true);
+
+      // Start elapsed timer
+      timerRef.current = setInterval(() => {
+        setElapsedSeconds((prev: number) => prev + 1);
+      }, 1000);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '開始に失敗しました');
+    }
+  }, [selectedContext, currentTier, deepgram, audio, setRecording, setSessionId, setElapsedSeconds]);
+
+  const handleStop = useCallback(async () => {
+    // Stop audio and deepgram
+    audio.stopCapture();
+    deepgram.disconnect();
+    buffer.flush();
+
+    if (timerRef.current) clearInterval(timerRef.current);
+
+    // End session
+    if (sessionId) {
+      await fetch(`/api/sessions/${sessionId}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ endedAt: new Date().toISOString() }),
+      });
+    }
+
+    reset();
+    translation.clearTranslations();
+    router.push('/');
+  }, [audio, deepgram, buffer, sessionId, reset, translation, router]);
+
+  const handleCloseRequest = () => {
+    if (isRecording) {
+      setShowCloseConfirm(true);
+    } else {
+      router.push('/');
+    }
+  };
+
+  return (
+    <div className="flex min-h-screen flex-col">
+      {/* Header */}
+      <header className="flex h-14 items-center justify-between border-b border-border px-4">
+        <button onClick={handleCloseRequest} className="text-sm text-muted-foreground">
+          {isRecording ? '× 閉じる' : '← 戻る'}
+        </button>
+        <span className="text-sm font-medium">
+          {isRecording
+            ? selectedContext?.title ?? 'フリーセッション'
+            : 'ライブ翻訳'}
+        </span>
+        <div className="w-10" />
+      </header>
+
+      {/* Main content */}
+      <div className="flex flex-1 flex-col">
+        {!isRecording && (
+          <div className="space-y-4 p-4">
+            {/* Context selector */}
+            <div>
+              <label className="mb-2 block text-sm font-medium">コンテキスト</label>
+              <ContextSelector
+                selectedId={selectedContext?.id ?? null}
+                onChange={setSelectedContext}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Subtitle display area */}
+        {isRecording && (
+          <SubtitleDisplay
+            translations={translation.translations}
+            interimText={interimText}
+          />
+        )}
+
+        {/* Silence warning */}
+        {audio.silenceWarning && isRecording && (
+          <div className="mx-4 mb-2 rounded-lg bg-warning/20 p-3 text-center text-sm text-warning">
+            音声が検出されません。マイクを確認してください
+          </div>
+        )}
+
+        {/* Error display */}
+        {error && (
+          <div className="mx-4 mb-2 rounded-lg bg-destructive/20 p-3 text-center text-sm text-destructive">
+            {error}
+          </div>
+        )}
+
+        {/* Controls */}
+        <LiveControls
+          isRecording={isRecording}
+          tier={currentTier}
+          elapsedSeconds={elapsedSeconds}
+          volume={audio.volume}
+          onStart={handleStart}
+          onStop={handleStop}
+          onTierChange={setCurrentTier}
+        />
+      </div>
+
+      {/* Close confirmation dialog */}
+      {showCloseConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-sm rounded-2xl bg-background p-6">
+            <h3 className="text-lg font-semibold">セッションを終了しますか？</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              録音中のデータは保存されます。
+            </p>
+            <div className="mt-6 flex gap-3">
+              <button
+                onClick={() => setShowCloseConfirm(false)}
+                className="flex-1 rounded-xl border border-border py-3 text-sm font-medium"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={() => {
+                  setShowCloseConfirm(false);
+                  handleStop();
+                }}
+                className="flex-1 rounded-xl bg-primary py-3 text-sm font-medium text-primary-foreground"
+              >
+                保存して終了
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/live/ContextSelector.tsx
+++ b/src/components/live/ContextSelector.tsx
@@ -1,0 +1,87 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+interface Context {
+  id: string;
+  title: string;
+  context_type: string;
+  glossary: { en: string; ja: string }[];
+  keywords: string[];
+}
+
+interface ContextSelectorProps {
+  selectedId: string | null;
+  onChange: (context: Context | null) => void;
+  disabled?: boolean;
+}
+
+export function ContextSelector({ selectedId, onChange, disabled }: ContextSelectorProps) {
+  const [contexts, setContexts] = useState<Context[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/contexts?limit=50')
+      .then((res) => res.json())
+      .then((result) => setContexts(result.data ?? []));
+  }, []);
+
+  const selected = contexts.find((c) => c.id === selectedId);
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => !disabled && setIsOpen(!isOpen)}
+        disabled={disabled}
+        className="flex h-12 w-full items-center justify-between rounded-xl border border-border bg-input px-4 text-sm disabled:opacity-50"
+      >
+        <span>{selected?.title ?? 'フリーセッション（コンテキストなし）'}</span>
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="16"
+          height="16"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <path d="m6 9 6 6 6-6" />
+        </svg>
+      </button>
+
+      {isOpen && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setIsOpen(false)} />
+          <div className="absolute left-0 right-0 z-50 mt-1 max-h-60 overflow-y-auto rounded-xl border border-border bg-background shadow-lg">
+            <button
+              onClick={() => {
+                onChange(null);
+                setIsOpen(false);
+              }}
+              className="w-full px-4 py-3 text-left text-sm hover:bg-accent"
+            >
+              フリーセッション（コンテキストなし）
+            </button>
+            {contexts.map((ctx) => (
+              <button
+                key={ctx.id}
+                onClick={() => {
+                  onChange(ctx);
+                  setIsOpen(false);
+                }}
+                className={`w-full px-4 py-3 text-left text-sm hover:bg-accent ${
+                  ctx.id === selectedId ? 'bg-accent' : ''
+                }`}
+              >
+                {ctx.title}
+              </button>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/live/LiveControls.tsx
+++ b/src/components/live/LiveControls.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+type TranslationTier = 'lite' | 'standard' | 'premium';
+
+interface LiveControlsProps {
+  isRecording: boolean;
+  tier: TranslationTier;
+  elapsedSeconds: number;
+  volume: number;
+  onStart: () => void;
+  onStop: () => void;
+  onTierChange: (tier: TranslationTier) => void;
+}
+
+const tierOptions: { value: TranslationTier; label: string; sub: string }[] = [
+  { value: 'lite', label: 'lite', sub: '案内板' },
+  { value: 'standard', label: 'standard', sub: 'アトラクション' },
+  { value: 'premium', label: 'premium', sub: '演劇' },
+];
+
+function formatTime(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+    .toString()
+    .padStart(2, '0');
+  const s = (seconds % 60).toString().padStart(2, '0');
+  return `${m}:${s}`;
+}
+
+export function LiveControls({
+  isRecording,
+  tier,
+  elapsedSeconds,
+  volume,
+  onStart,
+  onStop,
+  onTierChange,
+}: LiveControlsProps) {
+  if (isRecording) {
+    return (
+      <div className="flex flex-col items-center gap-3 p-4">
+        {/* Volume indicator */}
+        <div className="flex items-center gap-2">
+          <div className="flex h-4 items-end gap-0.5">
+            {[0.2, 0.4, 0.6, 0.8, 1.0].map((threshold, i) => (
+              <div
+                key={i}
+                className={`w-1 rounded-full transition-all ${
+                  volume >= threshold ? 'bg-primary' : 'bg-muted'
+                }`}
+                style={{ height: `${(i + 1) * 3 + 4}px` }}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Stop button */}
+        <button
+          onClick={onStop}
+          className="flex h-[52px] w-full items-center justify-center gap-2 rounded-xl bg-destructive text-sm font-medium text-white"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="18"
+            height="18"
+            viewBox="0 0 24 24"
+            fill="currentColor"
+          >
+            <rect x="6" y="6" width="12" height="12" rx="2" />
+          </svg>
+          録音停止
+        </button>
+
+        {/* Recording indicator */}
+        <div className="flex items-center gap-2 text-sm">
+          <span className="h-2 w-2 animate-pulse rounded-full bg-destructive" />
+          <span className="text-destructive font-medium">REC</span>
+          <span className="text-muted-foreground">{formatTime(elapsedSeconds)}</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      {/* Tier selector */}
+      <div>
+        <label className="mb-2 block text-sm font-medium">翻訳ティア</label>
+        <div className="flex rounded-[22px] bg-muted p-1">
+          {tierOptions.map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => onTierChange(opt.value)}
+              className={`flex-1 rounded-[18px] py-2 text-center transition-colors ${
+                tier === opt.value ? 'bg-background shadow-sm' : 'text-muted-foreground'
+              }`}
+            >
+              <span className="text-xs font-medium">{opt.label}</span>
+              <br />
+              <span className="text-[10px] text-muted-foreground">{opt.sub}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Start button */}
+      <button
+        onClick={onStart}
+        className="flex h-[52px] w-full items-center justify-center gap-2 rounded-xl bg-primary text-sm font-medium text-primary-foreground"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          width="18"
+          height="18"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="2"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        >
+          <circle cx="12" cy="12" r="10" />
+          <circle cx="12" cy="12" r="4" fill="currentColor" />
+        </svg>
+        録音開始
+      </button>
+    </div>
+  );
+}

--- a/src/components/live/SubtitleDisplay.tsx
+++ b/src/components/live/SubtitleDisplay.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import type { TranslationEntry } from '@/hooks/useTranslation';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+interface SubtitleDisplayProps {
+  translations: TranslationEntry[];
+  interimText: string;
+}
+
+const fontSizeMap = {
+  small: 'text-base',
+  medium: 'text-xl',
+  large: 'text-2xl',
+};
+
+export function SubtitleDisplay({ translations, interimText }: SubtitleDisplayProps) {
+  const { fontSize, showOriginal } = useSettingsStore();
+  const sizeClass = fontSizeMap[fontSize];
+
+  // Show last 3 translations
+  const visible = translations.slice(-3);
+
+  return (
+    <div className="flex flex-1 flex-col justify-end p-4">
+      {/* Interim transcription (top area) */}
+      {interimText && (
+        <p className="mb-4 text-sm text-muted-foreground/50 italic">{interimText}</p>
+      )}
+
+      {/* Subtitle entries */}
+      <div className="space-y-3">
+        {visible.map((entry, i) => {
+          const isLatest = i === visible.length - 1;
+          const opacity = isLatest ? 'opacity-100' : i === visible.length - 2 ? 'opacity-50' : 'opacity-30';
+
+          return (
+            <div key={entry.sequenceNumber} className={`transition-opacity duration-500 ${opacity}`}>
+              {showOriginal && entry.original && (
+                <p className="text-sm text-muted-foreground">{entry.original}</p>
+              )}
+              <p className={`font-medium leading-relaxed ${sizeClass}`}>
+                {entry.translated}
+                {entry.isStreaming && (
+                  <span className="ml-1 inline-block h-4 w-0.5 animate-pulse bg-foreground" />
+                )}
+              </p>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useAudioCapture.ts
+++ b/src/hooks/useAudioCapture.ts
@@ -1,0 +1,103 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+interface UseAudioCaptureReturn {
+  isCapturing: boolean;
+  volume: number;
+  silenceWarning: boolean;
+  startCapture: (onData: (data: Blob) => void) => Promise<void>;
+  stopCapture: () => void;
+}
+
+export function useAudioCapture(): UseAudioCaptureReturn {
+  const [isCapturing, setIsCapturing] = useState(false);
+  const [volume, setVolume] = useState(0);
+  const [silenceWarning, setSilenceWarning] = useState(false);
+
+  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
+  const animFrameRef = useRef<number>(0);
+  const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const wakeLockRef = useRef<WakeLockSentinel | null>(null);
+
+  const startCapture = useCallback(async (onData: (data: Blob) => void) => {
+    const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    streamRef.current = stream;
+
+    // Audio analysis for volume meter
+    const audioCtx = new AudioContext();
+    const source = audioCtx.createMediaStreamSource(stream);
+    const analyser = audioCtx.createAnalyser();
+    analyser.fftSize = 256;
+    source.connect(analyser);
+    analyserRef.current = analyser;
+
+    // Volume monitoring
+    const dataArray = new Uint8Array(analyser.frequencyBinCount);
+    const updateVolume = () => {
+      analyser.getByteFrequencyData(dataArray);
+      const avg = dataArray.reduce((sum, v) => sum + v, 0) / dataArray.length;
+      const normalized = Math.min(avg / 128, 1);
+      setVolume(normalized);
+
+      if (normalized < 0.02) {
+        if (!silenceTimerRef.current) {
+          silenceTimerRef.current = setTimeout(() => setSilenceWarning(true), 5000);
+        }
+      } else {
+        if (silenceTimerRef.current) {
+          clearTimeout(silenceTimerRef.current);
+          silenceTimerRef.current = null;
+        }
+        setSilenceWarning(false);
+      }
+
+      animFrameRef.current = requestAnimationFrame(updateVolume);
+    };
+    updateVolume();
+
+    // MediaRecorder
+    const mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+      ? 'audio/webm;codecs=opus'
+      : 'audio/mp4';
+
+    const recorder = new MediaRecorder(stream, { mimeType });
+    recorder.ondataavailable = (e) => {
+      if (e.data.size > 0) onData(e.data);
+    };
+    recorder.start(250); // 250ms chunks
+    mediaRecorderRef.current = recorder;
+
+    // Wake Lock
+    try {
+      if ('wakeLock' in navigator) {
+        wakeLockRef.current = await navigator.wakeLock.request('screen');
+      }
+    } catch {
+      // Wake Lock not available
+    }
+
+    setIsCapturing(true);
+  }, []);
+
+  const stopCapture = useCallback(() => {
+    mediaRecorderRef.current?.stop();
+    streamRef.current?.getTracks().forEach((t) => t.stop());
+    cancelAnimationFrame(animFrameRef.current);
+    if (silenceTimerRef.current) clearTimeout(silenceTimerRef.current);
+    wakeLockRef.current?.release();
+
+    mediaRecorderRef.current = null;
+    streamRef.current = null;
+    analyserRef.current = null;
+    wakeLockRef.current = null;
+
+    setIsCapturing(false);
+    setVolume(0);
+    setSilenceWarning(false);
+  }, []);
+
+  return { isCapturing, volume, silenceWarning, startCapture, stopCapture };
+}

--- a/src/hooks/useDeepgramLive.ts
+++ b/src/hooks/useDeepgramLive.ts
@@ -1,0 +1,121 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+interface DeepgramResult {
+  text: string;
+  isFinal: boolean;
+}
+
+interface UseDeepgramLiveReturn {
+  isConnected: boolean;
+  connect: (keywords?: string[]) => Promise<void>;
+  disconnect: () => void;
+  sendAudio: (data: Blob) => void;
+  onTranscript: (handler: (result: DeepgramResult) => void) => void;
+}
+
+export function useDeepgramLive(): UseDeepgramLiveReturn {
+  const [isConnected, setIsConnected] = useState(false);
+  const wsRef = useRef<WebSocket | null>(null);
+  const handlerRef = useRef<((result: DeepgramResult) => void) | null>(null);
+  const keepAliveRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const tokenTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const keywordsRef = useRef<string[]>([]);
+
+  const getToken = async (): Promise<string> => {
+    const res = await fetch('/api/deepgram-token', { method: 'POST' });
+    if (!res.ok) throw new Error('Failed to get Deepgram token');
+    const data = await res.json();
+    return data.token;
+  };
+
+  const connectWs = useCallback(async (token: string) => {
+    const keywords = keywordsRef.current;
+    let url = 'wss://api.deepgram.com/v1/listen?model=nova-3&language=en&punctuate=true&interim_results=true&utterance_end_ms=2000';
+
+    if (keywords.length > 0) {
+      const keywordParam = keywords.map((k) => `${encodeURIComponent(k)}:2`).join('&keywords=');
+      url += `&keywords=${keywordParam}`;
+    }
+
+    return new Promise<WebSocket>((resolve, reject) => {
+      const ws = new WebSocket(url, ['token', token]);
+
+      ws.onopen = () => {
+        setIsConnected(true);
+        resolve(ws);
+      };
+
+      ws.onmessage = (event) => {
+        try {
+          const data = JSON.parse(event.data);
+          const transcript = data?.channel?.alternatives?.[0]?.transcript;
+          if (transcript) {
+            handlerRef.current?.({
+              text: transcript,
+              isFinal: data.is_final === true,
+            });
+          }
+        } catch {
+          // Skip invalid messages
+        }
+      };
+
+      ws.onerror = () => reject(new Error('WebSocket connection failed'));
+      ws.onclose = () => setIsConnected(false);
+    });
+  }, []);
+
+  const connect = useCallback(async (keywords?: string[]) => {
+    keywordsRef.current = keywords ?? [];
+    const token = await getToken();
+    const ws = await connectWs(token);
+    wsRef.current = ws;
+
+    // KeepAlive every 5s
+    keepAliveRef.current = setInterval(() => {
+      if (ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'KeepAlive' }));
+      }
+    }, 5000);
+
+    // Token refresh at 9 minutes (90% of TTL)
+    tokenTimerRef.current = setTimeout(async () => {
+      try {
+        const newToken = await getToken();
+        // Close old connection
+        ws.send(JSON.stringify({ type: 'CloseStream' }));
+        ws.close();
+        // Reconnect with new token
+        const newWs = await connectWs(newToken);
+        wsRef.current = newWs;
+      } catch {
+        // Token refresh failed, connection will eventually timeout
+      }
+    }, 9 * 60 * 1000);
+  }, [connectWs]);
+
+  const disconnect = useCallback(() => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(JSON.stringify({ type: 'CloseStream' }));
+      wsRef.current.close();
+    }
+    wsRef.current = null;
+    if (keepAliveRef.current) clearInterval(keepAliveRef.current);
+    if (tokenTimerRef.current) clearTimeout(tokenTimerRef.current);
+    setIsConnected(false);
+  }, []);
+
+  const sendAudio = useCallback((data: Blob) => {
+    if (wsRef.current?.readyState === WebSocket.OPEN) {
+      wsRef.current.send(data);
+    }
+  }, []);
+
+  const onTranscript = useCallback((handler: (result: DeepgramResult) => void) => {
+    handlerRef.current = handler;
+  }, []);
+
+  return { isConnected, connect, disconnect, sendAudio, onTranscript };
+}

--- a/src/hooks/useTranslation.ts
+++ b/src/hooks/useTranslation.ts
@@ -1,0 +1,123 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+export interface TranslationEntry {
+  sequenceNumber: number;
+  original: string;
+  translated: string;
+  isStreaming: boolean;
+}
+
+interface TranslateParams {
+  utterance: string;
+  context?: {
+    title?: string;
+    type?: string;
+    description?: string;
+    glossary?: { en: string; ja: string }[];
+  };
+  tier: 'lite' | 'standard' | 'premium';
+  sessionId: string;
+}
+
+interface UseTranslationReturn {
+  translations: TranslationEntry[];
+  translate: (params: TranslateParams) => void;
+  clearTranslations: () => void;
+}
+
+export function useTranslation(): UseTranslationReturn {
+  const [translations, setTranslations] = useState<TranslationEntry[]>([]);
+  const seqRef = useRef(0);
+  const historyRef = useRef<{ original: string; translated: string }[]>([]);
+
+  const translate = useCallback((params: TranslateParams) => {
+    const sequenceNumber = seqRef.current++;
+
+    // Add placeholder entry
+    setTranslations((prev) => [
+      ...prev,
+      { sequenceNumber, original: params.utterance, translated: '', isStreaming: true },
+    ]);
+
+    // Build history (sliding window of last 3)
+    const history = historyRef.current.slice(-3);
+
+    // Start SSE request
+    fetch('/api/translate', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...params,
+        sequenceNumber,
+        history,
+      }),
+    }).then(async (res) => {
+      if (!res.ok || !res.body) {
+        setTranslations((prev) =>
+          prev.map((t) =>
+            t.sequenceNumber === sequenceNumber
+              ? { ...t, translated: '(翻訳エラー)', isStreaming: false }
+              : t,
+          ),
+        );
+        return;
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        buffer += decoder.decode(value, { stream: true });
+        const lines = buffer.split('\n');
+        buffer = lines.pop() ?? '';
+
+        for (const line of lines) {
+          if (!line.startsWith('data: ')) continue;
+          try {
+            const data = JSON.parse(line.slice(6));
+            if (data.done) {
+              // Final message
+              setTranslations((prev) =>
+                prev.map((t) =>
+                  t.sequenceNumber === sequenceNumber
+                    ? { ...t, translated: data.text, isStreaming: false }
+                    : t,
+                ),
+              );
+              // Add to history
+              historyRef.current.push({
+                original: params.utterance,
+                translated: data.text,
+              });
+            } else if (data.text) {
+              // Streaming chunk - append
+              setTranslations((prev) =>
+                prev.map((t) =>
+                  t.sequenceNumber === sequenceNumber
+                    ? { ...t, translated: t.translated + data.text }
+                    : t,
+                ),
+              );
+            }
+          } catch {
+            // Skip malformed data
+          }
+        }
+      }
+    });
+  }, []);
+
+  const clearTranslations = useCallback(() => {
+    setTranslations([]);
+    seqRef.current = 0;
+    historyRef.current = [];
+  }, []);
+
+  return { translations, translate, clearTranslations };
+}

--- a/src/hooks/useUtteranceBuffer.ts
+++ b/src/hooks/useUtteranceBuffer.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { useCallback, useRef } from 'react';
+
+interface UseUtteranceBufferReturn {
+  addText: (text: string, isFinal: boolean) => void;
+  onUtterance: (handler: (utterance: string) => void) => void;
+  flush: () => void;
+}
+
+// Simple token count estimation (split by spaces)
+function estimateTokens(text: string): number {
+  return text.split(/\s+/).filter(Boolean).length;
+}
+
+export function useUtteranceBuffer(): UseUtteranceBufferReturn {
+  const bufferRef = useRef<string[]>([]);
+  const handlerRef = useRef<((utterance: string) => void) | null>(null);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const emitUtterance = useCallback(() => {
+    const text = bufferRef.current.join(' ').trim();
+    if (text) {
+      handlerRef.current?.(text);
+      bufferRef.current = [];
+    }
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  }, []);
+
+  const resetTimer = useCallback(() => {
+    if (timerRef.current) clearTimeout(timerRef.current);
+    timerRef.current = setTimeout(emitUtterance, 2000); // 2s silence timeout
+  }, [emitUtterance]);
+
+  const addText = useCallback(
+    (text: string, isFinal: boolean) => {
+      if (!isFinal) return; // Only process final transcripts
+
+      bufferRef.current.push(text);
+      const combined = bufferRef.current.join(' ');
+      const tokens = estimateTokens(combined);
+
+      if (tokens >= 50) {
+        // Max token limit reached, emit
+        emitUtterance();
+      } else if (tokens >= 15) {
+        // Min threshold reached, start/reset timer
+        resetTimer();
+      } else {
+        // Below min threshold, wait for more
+        resetTimer();
+      }
+    },
+    [emitUtterance, resetTimer],
+  );
+
+  const flush = useCallback(() => {
+    emitUtterance();
+  }, [emitUtterance]);
+
+  const onUtterance = useCallback((handler: (utterance: string) => void) => {
+    handlerRef.current = handler;
+  }, []);
+
+  return { addText, onUtterance, flush };
+}

--- a/src/stores/liveStore.ts
+++ b/src/stores/liveStore.ts
@@ -12,10 +12,10 @@ type LiveState = {
 
 type LiveActions = {
   setRecording: (isRecording: boolean) => void;
-  setTier: (tier: TranslationTier) => void;
+  setCurrentTier: (tier: TranslationTier) => void;
   setSessionId: (id: string | null) => void;
   setContextId: (id: string | null) => void;
-  setElapsedSeconds: (seconds: number) => void;
+  setElapsedSeconds: (seconds: number | ((prev: number) => number)) => void;
   reset: () => void;
 };
 
@@ -30,9 +30,12 @@ const initialState: LiveState = {
 export const useLiveStore = create<LiveState & LiveActions>()((set) => ({
   ...initialState,
   setRecording: (isRecording) => set({ isRecording }),
-  setTier: (tier) => set({ currentTier: tier }),
+  setCurrentTier: (tier) => set({ currentTier: tier }),
   setSessionId: (id) => set({ sessionId: id }),
   setContextId: (id) => set({ contextId: id }),
-  setElapsedSeconds: (seconds) => set({ elapsedSeconds: seconds }),
+  setElapsedSeconds: (seconds) =>
+    set((state) => ({
+      elapsedSeconds: typeof seconds === 'function' ? seconds(state.elapsedSeconds) : seconds,
+    })),
   reset: () => set(initialState),
 }));


### PR DESCRIPTION
## Summary

Complete live translation implementation including:
- **Audio capture hooks**: mic input, MediaRecorder, volume monitoring, silence detection, Wake Lock
- **Deepgram WebSocket**: direct connection, token refresh, KeepAlive, keyword boosting
- **Utterance buffer**: smart combining (15-50 tokens), 2s silence timeout
- **Translation SSE client**: streaming display, sequence ordering, history window
- **Subtitle display**: last 3 translations with fade, font size settings, original text toggle
- **Live controls**: tier selector, start/stop, volume indicator, recording time
- **Context selector**: dropdown with context list for translation context
- **Live page**: full integration with session management, close confirmation

## Sprint 3 Tasks (Frontend)

- 3-2: マイク入力フック + AudioCapture UI
- 3-3: Deepgram WebSocket接続フック
- 3-4: UtteranceBufferフック
- 3-8: SSE翻訳ストリーミングフック
- 3-9: ライブセッション統合フック
- 3-10: 字幕表示コンポーネント
- 3-11: 中間文字起こし表示
- 3-12: ライブ翻訳操作UI
- 3-13: コンテキストセレクタ
- 3-14: ライブ翻訳画面統合
- 3-15: ライブ翻訳状態ストア

Closes #95
Closes #96

## Test plan

- [ ] Mic permission request on start
- [ ] Audio recording with volume indicator
- [ ] Silence detection warning after 5s
- [ ] Deepgram transcription streaming
- [ ] Utterance combining and translation trigger
- [ ] SSE streaming subtitle display
- [ ] Tier selection works before and during recording
- [ ] Context pre-selection via URL param
- [ ] Close confirmation during recording
- [ ] Session saved on stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)