### PR TITLE
feat: Sprint 4 session management UI + settings + heartbeat

### DIFF
--- a/src/app/(app)/live/page.tsx
+++ b/src/app/(app)/live/page.tsx
@@ -119,7 +119,7 @@ export default function LivePage() {
         setElapsedSeconds((prev: number) => prev + 1);
       }, 1000);
 
-      // Start heartbeat (every 30s) to keep session alive
+      // Start heartbeat (every 5min) to keep session alive
       heartbeatRef.current = setInterval(async () => {
         if (session.id) {
           await fetch(`/api/sessions/${session.id}`, {
@@ -128,7 +128,7 @@ export default function LivePage() {
             body: JSON.stringify({ endedAt: new Date().toISOString() }),
           }).catch(() => {});
         }
-      }, 30000);
+      }, 5 * 60 * 1000);
     } catch (err) {
       setError(err instanceof Error ? err.message : '開始に失敗しました');
     }

--- a/src/app/(app)/live/page.tsx
+++ b/src/app/(app)/live/page.tsx
@@ -38,6 +38,7 @@ export default function LivePage() {
   const buffer = useUtteranceBuffer();
   const translation = useTranslation();
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   // Set initial tier from settings
   useEffect(() => {
@@ -117,6 +118,17 @@ export default function LivePage() {
       timerRef.current = setInterval(() => {
         setElapsedSeconds((prev: number) => prev + 1);
       }, 1000);
+
+      // Start heartbeat (every 30s) to keep session alive
+      heartbeatRef.current = setInterval(async () => {
+        if (session.id) {
+          await fetch(`/api/sessions/${session.id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ endedAt: new Date().toISOString() }),
+          }).catch(() => {});
+        }
+      }, 30000);
     } catch (err) {
       setError(err instanceof Error ? err.message : '開始に失敗しました');
     }
@@ -129,6 +141,7 @@ export default function LivePage() {
     buffer.flush();
 
     if (timerRef.current) clearInterval(timerRef.current);
+    if (heartbeatRef.current) clearInterval(heartbeatRef.current);
 
     // End session
     if (sessionId) {

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -47,7 +47,7 @@ export default function HomePage() {
 
         if (usageRes.ok) {
           const usageJson = await usageRes.json();
-          setMonthlyMinutes(Math.round((usageJson.totalSeconds ?? 0) / 60));
+          setMonthlyMinutes(Math.floor((usageJson.totalSeconds ?? 0) / 60));
         }
       } catch {
         // Silently handle fetch errors

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -104,6 +104,26 @@ export default function HomePage() {
       </div>
 
       {/* New session button */}
+      {remaining === 0 ? (
+        <div className="flex h-[52px] w-full cursor-not-allowed items-center justify-center gap-2 rounded-xl bg-muted text-sm font-medium text-muted-foreground">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="20"
+            height="20"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
+            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+            <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+            <line x1="12" x2="12" y1="19" y2="22" />
+          </svg>
+          月間利用上限に達しました
+        </div>
+      ) : (
       <Link
         href="/live"
         className="flex h-[52px] w-full items-center justify-center gap-2 rounded-xl bg-primary text-sm font-medium text-primary-foreground transition-opacity hover:opacity-90"
@@ -125,6 +145,7 @@ export default function HomePage() {
         </svg>
         新しいセッションを開始
       </Link>
+      )}
 
       {/* Recent sessions section */}
       <div>

--- a/src/app/(app)/page.tsx
+++ b/src/app/(app)/page.tsx
@@ -1,16 +1,67 @@
+'use client';
+
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { SessionCard } from '@/components/sessions/SessionCard';
+
+interface Session {
+  id: string;
+  title: string;
+  translation_tier: 'lite' | 'standard' | 'premium';
+  started_at: string;
+  duration_seconds: number | null;
+}
 
 export default function HomePage() {
+  const [sessions, setSessions] = useState<Session[]>([]);
+  const [monthlyMinutes, setMonthlyMinutes] = useState(0);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        // Fetch recent sessions
+        const res = await fetch('/api/sessions?limit=10');
+        if (res.ok) {
+          const json = await res.json();
+          setSessions(json.data ?? []);
+
+          // Calculate monthly usage from sessions this month
+          const now = new Date();
+          const monthStart = new Date(now.getFullYear(), now.getMonth(), 1);
+          const thisMonthSessions = (json.data ?? []) as Session[];
+          const totalSeconds = thisMonthSessions
+            .filter((s) => new Date(s.started_at) >= monthStart && s.duration_seconds)
+            .reduce((sum: number, s: Session) => sum + (s.duration_seconds ?? 0), 0);
+          setMonthlyMinutes(Math.round(totalSeconds / 60));
+        }
+      } catch {
+        // Silently handle fetch errors
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  const maxMinutes = 60;
+  const usagePercent = Math.min((monthlyMinutes / maxMinutes) * 100, 100);
+
   return (
     <div className="mx-auto max-w-lg space-y-6 p-4">
-      {/* Monthly usage placeholder */}
+      {/* Monthly usage */}
       <div className="rounded-xl bg-card p-4">
         <p className="text-sm font-medium text-muted-foreground">月間利用時間</p>
         <div className="mt-2 flex items-center gap-3">
           <div className="h-2 flex-1 rounded-full bg-muted">
-            <div className="h-2 w-0 rounded-full bg-primary" />
+            <div
+              className="h-2 rounded-full bg-primary transition-all"
+              style={{ width: `${usagePercent}%` }}
+            />
           </div>
-          <span className="text-sm font-medium">0分 / 60分</span>
+          <span className="text-sm font-medium">
+            {monthlyMinutes}分 / {maxMinutes}分
+          </span>
         </div>
       </div>
 
@@ -40,29 +91,49 @@ export default function HomePage() {
       {/* Recent sessions section */}
       <div>
         <h2 className="mb-3 text-sm font-medium">最近のセッション</h2>
-        <div className="flex flex-col items-center py-12 text-center">
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="48"
-            height="48"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="1.5"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="text-muted-foreground/50"
-          >
-            <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
-            <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
-            <line x1="12" x2="12" y1="19" y2="22" />
-          </svg>
-          <p className="mt-4 text-sm text-muted-foreground">
-            セッションがありません。
-            <br />
-            新しいセッションを開始しましょう。
-          </p>
-        </div>
+
+        {loading ? (
+          <div className="flex justify-center py-12">
+            <div className="h-6 w-6 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+          </div>
+        ) : sessions.length === 0 ? (
+          <div className="flex flex-col items-center py-12 text-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="48"
+              height="48"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              className="text-muted-foreground/50"
+            >
+              <path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z" />
+              <path d="M19 10v2a7 7 0 0 1-14 0v-2" />
+              <line x1="12" x2="12" y1="19" y2="22" />
+            </svg>
+            <p className="mt-4 text-sm text-muted-foreground">
+              セッションがありません。
+              <br />
+              新しいセッションを開始しましょう。
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {sessions.map((s) => (
+              <SessionCard
+                key={s.id}
+                id={s.id}
+                title={s.title}
+                translation_tier={s.translation_tier}
+                started_at={s.started_at}
+                duration_seconds={s.duration_seconds}
+              />
+            ))}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/app/(app)/sessions/[id]/page.tsx
+++ b/src/app/(app)/sessions/[id]/page.tsx
@@ -95,7 +95,7 @@ export default function SessionDetailPage() {
     minute: '2-digit',
   });
 
-  const duration = session.duration_seconds
+  const duration = session.duration_seconds !== null
     ? `${Math.round(session.duration_seconds / 60)}分`
     : '進行中';
 

--- a/src/app/(app)/sessions/[id]/page.tsx
+++ b/src/app/(app)/sessions/[id]/page.tsx
@@ -53,9 +53,16 @@ export default function SessionDetailPage() {
     load();
   }, [id]);
 
+  const [deleteError, setDeleteError] = useState(false);
+
   const handleDelete = useCallback(async () => {
-    await fetch(`/api/sessions/${id}`, { method: 'DELETE' });
-    router.push('/');
+    setDeleteError(false);
+    const res = await fetch(`/api/sessions/${id}`, { method: 'DELETE' });
+    if (res.ok) {
+      router.push('/');
+    } else {
+      setDeleteError(true);
+    }
   }, [id, router]);
 
   if (loading) {
@@ -159,6 +166,9 @@ export default function SessionDetailPage() {
             <p className="mt-2 text-sm text-muted-foreground">
               この操作は取り消せません。トランスクリプトも削除されます。
             </p>
+            {deleteError && (
+              <p className="mt-2 text-sm text-destructive">削除に失敗しました。もう一度お試しください。</p>
+            )}
             <div className="mt-6 flex gap-3">
               <button
                 onClick={() => setShowDeleteConfirm(false)}

--- a/src/app/(app)/sessions/[id]/page.tsx
+++ b/src/app/(app)/sessions/[id]/page.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { TranscriptViewer } from '@/components/sessions/TranscriptViewer';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+interface Transcript {
+  id: string;
+  original_text: string;
+  translated_text: string;
+  timestamp_ms: number;
+}
+
+interface SessionDetail {
+  id: string;
+  title: string;
+  translation_tier: 'lite' | 'standard' | 'premium';
+  started_at: string;
+  ended_at: string | null;
+  duration_seconds: number | null;
+  transcripts: Transcript[];
+}
+
+const tierLabels = {
+  lite: 'Lite',
+  standard: 'Standard',
+  premium: 'Premium',
+};
+
+export default function SessionDetailPage() {
+  const router = useRouter();
+  const { id } = useParams<{ id: string }>();
+  const { fontSize, showOriginal, setFontSize, setShowOriginal } = useSettingsStore();
+
+  const [session, setSession] = useState<SessionDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch(`/api/sessions/${id}`);
+        if (res.ok) {
+          setSession(await res.json());
+        }
+      } catch {
+        // Silently handle
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, [id]);
+
+  const handleDelete = useCallback(async () => {
+    await fetch(`/api/sessions/${id}`, { method: 'DELETE' });
+    router.push('/');
+  }, [id, router]);
+
+  if (loading) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <div className="h-6 w-6 animate-spin rounded-full border-2 border-muted-foreground border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (!session) {
+    return (
+      <div className="flex min-h-[50vh] flex-col items-center justify-center gap-4">
+        <p className="text-muted-foreground">セッションが見つかりません</p>
+        <button onClick={() => router.push('/')} className="text-sm text-primary">
+          ホームに戻る
+        </button>
+      </div>
+    );
+  }
+
+  const date = new Date(session.started_at).toLocaleDateString('ja-JP', {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+
+  const time = new Date(session.started_at).toLocaleTimeString('ja-JP', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  const duration = session.duration_seconds
+    ? `${Math.round(session.duration_seconds / 60)}分`
+    : '進行中';
+
+  return (
+    <div className="mx-auto max-w-lg p-4">
+      {/* Back button */}
+      <button onClick={() => router.back()} className="mb-4 text-sm text-muted-foreground">
+        ← 戻る
+      </button>
+
+      {/* Session info */}
+      <div className="mb-6">
+        <h1 className="text-lg font-semibold">{session.title}</h1>
+        <div className="mt-1 flex items-center gap-2 text-sm text-muted-foreground">
+          <span>{date}</span>
+          <span>{time}</span>
+          <span>{tierLabels[session.translation_tier]}</span>
+          <span>{duration}</span>
+        </div>
+      </div>
+
+      {/* Display settings */}
+      <div className="mb-6 flex items-center gap-4 rounded-xl bg-card p-3">
+        <div className="flex items-center gap-2">
+          <label className="text-xs text-muted-foreground">文字サイズ</label>
+          <select
+            value={fontSize}
+            onChange={(e) => setFontSize(e.target.value as 'small' | 'medium' | 'large')}
+            className="rounded-lg border border-border bg-background px-2 py-1 text-xs"
+          >
+            <option value="small">小</option>
+            <option value="medium">中</option>
+            <option value="large">大</option>
+          </select>
+        </div>
+        <label className="flex items-center gap-1.5 text-xs text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={showOriginal}
+            onChange={(e) => setShowOriginal(e.target.checked)}
+            className="rounded"
+          />
+          原文表示
+        </label>
+      </div>
+
+      {/* Transcripts */}
+      <TranscriptViewer
+        transcripts={session.transcripts}
+        startedAt={session.started_at}
+      />
+
+      {/* Delete button */}
+      <div className="mt-8 border-t border-border pt-4">
+        <button
+          onClick={() => setShowDeleteConfirm(true)}
+          className="w-full rounded-xl border border-destructive py-3 text-sm font-medium text-destructive"
+        >
+          セッションを削除
+        </button>
+      </div>
+
+      {/* Delete confirmation */}
+      {showDeleteConfirm && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4">
+          <div className="w-full max-w-sm rounded-2xl bg-background p-6">
+            <h3 className="text-lg font-semibold">セッションを削除しますか？</h3>
+            <p className="mt-2 text-sm text-muted-foreground">
+              この操作は取り消せません。トランスクリプトも削除されます。
+            </p>
+            <div className="mt-6 flex gap-3">
+              <button
+                onClick={() => setShowDeleteConfirm(false)}
+                className="flex-1 rounded-xl border border-border py-3 text-sm font-medium"
+              >
+                キャンセル
+              </button>
+              <button
+                onClick={handleDelete}
+                className="flex-1 rounded-xl bg-destructive py-3 text-sm font-medium text-destructive-foreground"
+              >
+                削除
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/(app)/settings/page.tsx
+++ b/src/app/(app)/settings/page.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+import { useSettingsStore } from '@/stores/settingsStore';
+
+const tierOptions = [
+  { value: 'lite' as const, label: 'Lite', desc: '案内板・簡単な説明向け' },
+  { value: 'standard' as const, label: 'Standard', desc: 'アトラクション・一般翻訳' },
+  { value: 'premium' as const, label: 'Premium', desc: '演劇・文学的翻訳' },
+];
+
+export default function SettingsPage() {
+  const { fontSize, showOriginal, defaultTier, setFontSize, setShowOriginal, setDefaultTier } =
+    useSettingsStore();
+
+  return (
+    <div className="mx-auto max-w-lg p-4">
+      <h1 className="mb-6 text-lg font-semibold">設定</h1>
+
+      {/* Display settings */}
+      <section className="mb-6">
+        <h2 className="mb-3 text-sm font-medium text-muted-foreground">表示設定</h2>
+        <div className="space-y-4 rounded-xl bg-card p-4">
+          <div className="flex items-center justify-between">
+            <span className="text-sm">字幕の文字サイズ</span>
+            <select
+              value={fontSize}
+              onChange={(e) => setFontSize(e.target.value as 'small' | 'medium' | 'large')}
+              className="rounded-lg border border-border bg-background px-3 py-1.5 text-sm"
+            >
+              <option value="small">小</option>
+              <option value="medium">中</option>
+              <option value="large">大</option>
+            </select>
+          </div>
+          <div className="flex items-center justify-between">
+            <span className="text-sm">原文を表示</span>
+            <button
+              onClick={() => setShowOriginal(!showOriginal)}
+              className={`relative h-6 w-11 rounded-full transition-colors ${
+                showOriginal ? 'bg-primary' : 'bg-muted'
+              }`}
+            >
+              <span
+                className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white transition-transform ${
+                  showOriginal ? 'translate-x-5' : 'translate-x-0'
+                }`}
+              />
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* Translation settings */}
+      <section>
+        <h2 className="mb-3 text-sm font-medium text-muted-foreground">翻訳設定</h2>
+        <div className="space-y-2">
+          {tierOptions.map((opt) => (
+            <button
+              key={opt.value}
+              onClick={() => setDefaultTier(opt.value)}
+              className={`flex w-full items-center justify-between rounded-xl border p-4 text-left transition-colors ${
+                defaultTier === opt.value
+                  ? 'border-primary bg-primary/5'
+                  : 'border-border bg-card'
+              }`}
+            >
+              <div>
+                <p className="text-sm font-medium">{opt.label}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">{opt.desc}</p>
+              </div>
+              {defaultTier === opt.value && (
+                <div className="h-5 w-5 rounded-full bg-primary" />
+              )}
+            </button>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/api/sessions/monthly-usage/route.ts
+++ b/src/app/api/sessions/monthly-usage/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { getAuthUser } from '@/lib/auth';
+
+export async function GET() {
+  try {
+    const { supabase, user } = await getAuthUser();
+
+    // Get sum of duration_seconds for sessions this month
+    const now = new Date();
+    const monthStart = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+
+    const { data, error } = await supabase
+      .from('sessions')
+      .select('duration_seconds')
+      .eq('user_id', user.id)
+      .gte('started_at', monthStart)
+      .not('duration_seconds', 'is', null);
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    const totalSeconds = (data ?? []).reduce(
+      (sum, s) => sum + (s.duration_seconds ?? 0),
+      0,
+    );
+
+    return NextResponse.json({ totalSeconds });
+  } catch (e) {
+    if (e instanceof Response) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -68,10 +68,14 @@ export function Header() {
               <DropdownMenuSeparator />
             </>
           )}
-          <DropdownMenuItem onClick={handleLogout}>ログアウト</DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <Link href="/settings">設定</Link>
+          </DropdownMenuItem>
           <DropdownMenuItem asChild>
             <Link href="/legal">プライバシーポリシー</Link>
           </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem onClick={handleLogout}>ログアウト</DropdownMenuItem>
         </DropdownMenuContent>
       </DropdownMenu>
     </header>

--- a/src/components/sessions/SessionCard.tsx
+++ b/src/components/sessions/SessionCard.tsx
@@ -1,0 +1,41 @@
+import Link from 'next/link';
+
+interface SessionCardProps {
+  id: string;
+  title: string;
+  translation_tier: 'lite' | 'standard' | 'premium';
+  started_at: string;
+  duration_seconds: number | null;
+}
+
+export function SessionCard({
+  id,
+  title,
+  translation_tier,
+  started_at,
+  duration_seconds,
+}: SessionCardProps) {
+  const time = new Date(started_at).toLocaleTimeString('ja-JP', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  const duration = duration_seconds
+    ? `${Math.round(duration_seconds / 60)}分`
+    : '進行中';
+
+  return (
+    <Link
+      href={`/sessions/${id}`}
+      className="flex items-center justify-between rounded-xl bg-card p-4 transition-colors hover:bg-accent"
+    >
+      <div>
+        <p className="font-medium">{title}</p>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          {translation_tier} · {duration}
+        </p>
+      </div>
+      <span className="text-sm text-muted-foreground">{time}</span>
+    </Link>
+  );
+}

--- a/src/components/sessions/SessionCard.tsx
+++ b/src/components/sessions/SessionCard.tsx
@@ -6,6 +6,7 @@ interface SessionCardProps {
   translation_tier: 'lite' | 'standard' | 'premium';
   started_at: string;
   duration_seconds: number | null;
+  context_title: string | null;
 }
 
 export function SessionCard({
@@ -14,6 +15,7 @@ export function SessionCard({
   translation_tier,
   started_at,
   duration_seconds,
+  context_title,
 }: SessionCardProps) {
   const time = new Date(started_at).toLocaleTimeString('ja-JP', {
     hour: '2-digit',
@@ -32,6 +34,7 @@ export function SessionCard({
       <div>
         <p className="font-medium">{title}</p>
         <p className="mt-0.5 text-sm text-muted-foreground">
+          {context_title && <>{context_title} · </>}
           {translation_tier} · {duration}
         </p>
       </div>

--- a/src/components/sessions/SessionCard.tsx
+++ b/src/components/sessions/SessionCard.tsx
@@ -22,7 +22,7 @@ export function SessionCard({
     minute: '2-digit',
   });
 
-  const duration = duration_seconds
+  const duration = duration_seconds !== null
     ? `${Math.round(duration_seconds / 60)}分`
     : '進行中';
 

--- a/src/components/sessions/TranscriptViewer.tsx
+++ b/src/components/sessions/TranscriptViewer.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import { useSettingsStore } from '@/stores/settingsStore';
+
+interface Transcript {
+  id: string;
+  original_text: string;
+  translated_text: string;
+  timestamp_ms: number;
+}
+
+interface TranscriptViewerProps {
+  transcripts: Transcript[];
+  startedAt: string;
+}
+
+const fontSizeMap = {
+  small: 'text-sm',
+  medium: 'text-base',
+  large: 'text-lg',
+};
+
+export function TranscriptViewer({ transcripts, startedAt }: TranscriptViewerProps) {
+  const { fontSize, showOriginal } = useSettingsStore();
+  const sizeClass = fontSizeMap[fontSize];
+  const startTime = new Date(startedAt).getTime();
+
+  if (transcripts.length === 0) {
+    return (
+      <div className="flex flex-col items-center py-12 text-center">
+        <p className="text-sm text-muted-foreground">トランスクリプトがありません</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {transcripts.map((t) => {
+        const elapsed = Math.max(0, Math.round((t.timestamp_ms - startTime) / 1000));
+        const min = Math.floor(elapsed / 60);
+        const sec = elapsed % 60;
+        const timeLabel = `${String(min).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
+
+        return (
+          <div key={t.id} className="flex gap-3">
+            <span className="mt-0.5 shrink-0 text-xs text-muted-foreground">{timeLabel}</span>
+            <div className="min-w-0 flex-1">
+              {showOriginal && t.original_text && (
+                <p className="text-sm text-muted-foreground">{t.original_text}</p>
+              )}
+              <p className={`leading-relaxed ${sizeClass}`}>{t.translated_text}</p>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Home page fetches real session data and calculates monthly usage from API
- Session detail page (`/sessions/[id]`) with TranscriptViewer showing timestamped transcripts
- Settings page (`/settings`) for font size, original text toggle, and default translation tier
- Heartbeat (30s interval) on live page to update session duration during recording
- Header dropdown now includes settings link

Closes #99
Closes #100
Closes #101

## Sprint 4 Tasks
- 4-5: Live translation flow session integration (create/end/heartbeat)
- 4-7: Home page session list with real data
- 4-8: Monthly usage time display
- 4-9: Session detail with transcript viewer
- 4-10: Display settings (font size, original text)
- 4-12: Settings store integration

## Test plan
- [ ] Home page shows sessions fetched from API with correct usage stats
- [ ] Clicking a session card navigates to detail page with transcripts
- [ ] Session detail shows timestamps, original text toggle, font size control
- [ ] Delete session from detail page works with confirmation
- [ ] Settings page persists preferences via Zustand persist
- [ ] Live page creates session, sends heartbeat every 30s, ends session on stop
- [ ] Settings link accessible from header dropdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)